### PR TITLE
Add return type to format()

### DIFF
--- a/timeago/CHANGELOG.md
+++ b/timeago/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.0.3
+- Adds missing return type (`String`) to `format` function
+
 ## 2.0.2
 - Adds Nl translation thanks to @Elvander
 

--- a/timeago/analysis_options.yaml
+++ b/timeago/analysis_options.yaml
@@ -1,4 +1,6 @@
 analyzer:
+  strong-mode:
+    implicit-casts: false
   errors:
     unused_import: error
     unused_local_variable: error

--- a/timeago/lib/src/messages/lookupmessages.dart
+++ b/timeago/lib/src/messages/lookupmessages.dart
@@ -14,5 +14,5 @@ abstract class LookupMessages {
   String months(int months);
   String aboutAYear(int year);
   String years(int years);
-  wordSeparator() => ' ';
+  String wordSeparator() => ' ';
 }

--- a/timeago/lib/src/timeago.dart
+++ b/timeago/lib/src/timeago.dart
@@ -17,29 +17,32 @@ Map<String, LookupMessages> _lookupMessagesMap = {
 /// setLocaleMessages('fr', FrMessages())
 /// ```
 ///
-/// If you want to define locale message implement [LookupMessages] interface with
-/// the desired messages
+/// If you want to define locale message implement [LookupMessages] interface
+/// with the desired messages
 ///
-setLocaleMessages(String locale, LookupMessages lookupMessages) {
+void setLocaleMessages(String locale, LookupMessages lookupMessages) {
   assert(locale != null, '[locale] must not be null');
   assert(lookupMessages != null, '[lookupMessages] must not be null');
-  _lookupMessagesMap[locale] =  lookupMessages;
+  _lookupMessagesMap[locale] = lookupMessages;
 }
 
-///
 /// Formats provided [date] to a fuzzy time like 'a moment ago'
-/// If [locale] is passed will look for message for that locale, if you want to add or override locales use [setLocaleMessages]. Defaults to 'en'
-/// If [clock] is passed this will be the point of reference for calculating the elapsed time. Defaults to DateTime.now()
-/// if [allowFromNow] is passed, format will use the From prefix, ie. a date 5 minutes from now in 'en' locale will display as "5 minutes from now"
-format(DateTime date, { String locale, DateTime clock, allowFromNow }) {
+///
+/// - If [locale] is passed will look for message for that locale, if you want
+///   to add or override locales use [setLocaleMessages]. Defaults to 'en'
+/// - If [clock] is passed this will be the point of reference for calculating
+///   the elapsed time. Defaults to DateTime.now()
+/// - If [allowFromNow] is passed, format will use the From prefix, ie. a date
+///   5 minutes from now in 'en' locale will display as "5 minutes from now"
+String format(DateTime date,
+    {String locale, DateTime clock, bool allowFromNow}) {
   final _locale = locale ?? 'en';
   final _allowFromNow = allowFromNow ?? false;
   final messages = _lookupMessagesMap[_locale] ?? EnMessages();
   final _clock = clock ?? DateTime.now();
   var elapsed = _clock.millisecondsSinceEpoch - date.millisecondsSinceEpoch;
 
-  var prefix;
-  var suffix;
+  String prefix, suffix;
 
   if (_allowFromNow && elapsed < 0) {
     elapsed = date.isBefore(_clock) ? elapsed : elapsed.abs();

--- a/timeago/pubspec.yaml
+++ b/timeago/pubspec.yaml
@@ -1,7 +1,7 @@
 name: timeago
 description: >
   A library useful for creating fuzzy timestamps. (e.g. "15 minutes ago")
-version: 2.0.2
+version: 2.0.3
 author: Andres Araujo <a.araujo.azua@gmail.com>
 homepage: https://github.com/andresaraujo/timeago.dart
 


### PR DESCRIPTION
This PR also disables `implicit-casts` since that is quite dangerous in dart 2.0.0 and makes the necessary changes for it.

I have also done some slight cleanup to the docs, I hope that's OK.