### PR TITLE
Removed "geleden" suffix from in NL messages

### DIFF
--- a/timeago/lib/src/messages/nl_messages.dart
+++ b/timeago/lib/src/messages/nl_messages.dart
@@ -5,7 +5,7 @@ class NlMessages implements LookupMessages {
   String prefixFromNow() => 'over';
   String suffixAgo() => 'geleden';
   String suffixFromNow() => '';
-  String lessThanOneMinute(int seconds) => 'een moment geleden';
+  String lessThanOneMinute(int seconds) => 'een moment';
   String aboutAMinute(int minutes) => 'één minuut';
   String minutes(int minutes) => '$minutes minuten';
   String aboutAnHour(int minutes) => 'ongeveer één uur';


### PR DESCRIPTION
For NL messages, suffixAgo() is "geleden" but it also appears at the end of lessThanOneMinute() causing semantically incorrect messages like "een moment geleden geleden" (one moment ago ago). This change removes "geleden" from lessThanOneMinute().