### PR TITLE
Correcting brazilian portuguese redundancy

### DIFF
--- a/timeago/lib/src/messages/pt_br_messages.dart
+++ b/timeago/lib/src/messages/pt_br_messages.dart
@@ -3,7 +3,7 @@ import 'package:timeago/src/messages/lookupmessages.dart';
 class PtBrMessages implements LookupMessages {
   String prefixAgo() => 'Há';
   String prefixFromNow() => 'em';
-  String suffixAgo() => 'atrás';
+  String suffixAgo() => '';
   String suffixFromNow() => '';
   String lessThanOneMinute(int seconds) => 'poucos segundos';
   String aboutAMinute(int minutes) => 'um minuto';


### PR DESCRIPTION
Correcting portuguese language error. You can't have both the prefix and the suffix in brazilian portuguese, it's a redundancy.

Via: https://exame.abril.com.br/carreira/ha-dez-anos-atras-ou-dez-anos-atras-qual-e-o-certo/