### PR TITLE
Correct zh messages

### DIFF
--- a/timeago/lib/src/messages/zh_cn_messages.dart
+++ b/timeago/lib/src/messages/zh_cn_messages.dart
@@ -2,12 +2,12 @@ import 'package:timeago/src/messages/lookupmessages.dart';
 
 class ZhCnMessages implements LookupMessages {
   String prefixAgo() => '';
-  String prefixFromNow() => '不久以前';
+  String prefixFromNow() => '';
   String suffixAgo() => '前';
   String suffixFromNow() => '后';
   String lessThanOneMinute(int seconds) => '少于一分钟';
-  String aboutAMinute(int minutes) => '约1分钟前';
-  String minutes(int minutes) => '$minutes 分';
+  String aboutAMinute(int minutes) => '约1分钟';
+  String minutes(int minutes) => '${minutes} 分';
   String aboutAnHour(int minutes) => '约1小时';
   String hours(int hours) => '约 ${hours} 小时';
   String aDay(int hours) => '约1天';

--- a/timeago/lib/src/messages/zh_messages.dart
+++ b/timeago/lib/src/messages/zh_messages.dart
@@ -2,11 +2,11 @@ import 'package:timeago/src/messages/lookupmessages.dart';
 
 class ZhMessages implements LookupMessages {
   String prefixAgo() => '';
-  String prefixFromNow() => '從現在開始';
+  String prefixFromNow() => '';
   String suffixAgo() => '前';
   String suffixFromNow() => '後';
   String lessThanOneMinute(int seconds) => '少於一分鐘';
-  String aboutAMinute(int minutes) => '約1分鐘前';
+  String aboutAMinute(int minutes) => '約1分鐘';
   String minutes(int minutes) => '${minutes} 分';
   String aboutAnHour(int minutes) => '約1小時';
   String hours(int hours) => '約 ${hours} 小時';


### PR DESCRIPTION
- Remove `prefixFromNow` from messages
  - The same as [rmm5t/jquery-timeago](https://github.com/rmm5t/jquery-timeago/blob/master/locales/jquery.timeago.zh-CN.js#L13)

- Remove duplicated `suffixAgo` in `aboutAMinute`