### PR TITLE
Improve Polish messages

### DIFF
--- a/timeago/lib/src/messages/pl_messages.dart
+++ b/timeago/lib/src/messages/pl_messages.dart
@@ -7,19 +7,23 @@ class PlMessages implements LookupMessages {
   String suffixFromNow() => 'od tego momentu';
   String lessThanOneMinute(int seconds) => 'chwilę';
   String aboutAMinute(int minutes) => 'około minutę';
-  String minutes(int minutes) => _is234(minutes) ? '$minutes minuty' : '$minutes minut';
+  String minutes(int minutes) => _pluralize(minutes, 'minuty', 'minut');
   String aboutAnHour(int minutes) => 'około godzinę';
-  String hours(int hours) => _is234(hours) ? '$hours godziny' : '$hours godzin';
+  String hours(int hours) => _pluralize(hours, 'godziny', 'godzin');
   String aDay(int hours) => 'dzień';
   String days(int days) => '$days dni';
   String aboutAMonth(int days) => 'około miesiąc';
-  String months(int months) => _is234(months) ? '$months miesiące' : '$months miesięcy';
+  String months(int months) => _pluralize(months, 'miesiące', 'miesięcy');
   String aboutAYear(int year) => 'około rok';
-  String years(int years) => _is234(years) ? '$years lata' : '$years lat';
+  String years(int years) => _pluralize(years, 'lata', 'lat');
   String wordSeparator() => ' ';
-  
-  bool _is234(int v){
-    var mod = v % 10;
-    return (mod == 2 || mod == 3 || mod == 4) && (v / 10) != 1;
-  } 
+
+  String _pluralize(int n, String form1, String form2) {
+    // Rules as per https://www.gnu.org/software/gettext/manual/html_node/Plural-forms.html
+    if (n % 10 >= 2 && n % 10 <= 4 && (n % 100 < 10 || n % 100 >= 20)) {
+      return '$n $form1';
+    }
+
+    return '$n $form2';
+  }
 }


### PR DESCRIPTION
Hi,

Current Polish rules are too simple and yield invalid translations for a few numerals - I've provided an improved ruleset based on the [gettext's plural forms](https://www.gnu.org/software/gettext/manual/html_node/Plural-forms.html).

Thanks! :-)