### PR TITLE
Add short French messages

### DIFF
--- a/timeago/lib/src/messages/fr_messages.dart
+++ b/timeago/lib/src/messages/fr_messages.dart
@@ -18,3 +18,22 @@ class FrMessages implements LookupMessages {
   String years(int years) => '$years ans';
   String wordSeparator() => ' ';
 }
+
+class FrShortMessages implements LookupMessages {
+  String prefixAgo() => 'il y a';
+  String prefixFromNow() => "d'ici";
+  String suffixAgo() => '';
+  String suffixFromNow() => '';
+  String lessThanOneMinute(int seconds) => "moins d'une minute";
+  String aboutAMinute(int minutes) => 'une minute';
+  String minutes(int minutes) => '$minutes minutes';
+  String aboutAnHour(int minutes) => 'une heure';
+  String hours(int hours) => '$hours heures';
+  String aDay(int hours) => 'un jour';
+  String days(int days) => '$days jours';
+  String aboutAMonth(int days) => 'un mois';
+  String months(int months) => '$months mois';
+  String aboutAYear(int year) => 'un an';
+  String years(int years) => '$years ans';
+  String wordSeparator() => ' ';
+}


### PR DESCRIPTION
To reduce the message output length, I created a short version of the French messages removing 'environ' word everywhere because it's not an important word when you want a relative date string