### PR TITLE
Making flutter_timeago compatible with all timeago 2.x.x

### DIFF
--- a/timeago_flutter/CHANGELOG.md
+++ b/timeago_flutter/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [0.3.0] - Improvements to flutter widget to support auto refresh @kranfix.
 
 - Creating a TimerRefreshWidget as a base for TimerRefresh
+- Making packge compatible with timeago all 2.x.x
 
 ## [0.2.0] - Improvements to flutter widget to support auto refresh @kranfix.
 

--- a/timeago_flutter/pubspec.yaml
+++ b/timeago_flutter/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: ">=2.10.0 <3.0.0"
 
 dependencies:
-  timeago: ^2.0.27
+  timeago: ">=2.0.27 <3.0.0"
   flutter:
     sdk: flutter
 


### PR DESCRIPTION
Making flutter\_timeago compatible with all timeago 2.x.x