### PR TITLE
Migrated to null safety

### DIFF
--- a/timeago/lib/src/timeago.dart
+++ b/timeago/lib/src/timeago.dart
@@ -48,9 +48,9 @@ void setLocaleMessages(String locale, LookupMessages lookupMessages) {
 /// - If [allowFromNow] is passed, format will use the From prefix, ie. a date
 ///   5 minutes from now in 'en' locale will display as "5 minutes from now"
 String format(DateTime date,
-    {String? locale, DateTime? clock, bool? allowFromNow}) {
+    {String? locale, DateTime? clock, bool allowFromNow = false}) {
   final _locale = locale ?? _default;
-  final _allowFromNow = allowFromNow ?? false;
+  final _allowFromNow = allowFromNow;
   final messages = _lookupMessagesMap[_locale] ?? EnMessages();
   final _clock = clock ?? DateTime.now();
   var elapsed = _clock.millisecondsSinceEpoch - date.millisecondsSinceEpoch;

--- a/timeago/lib/src/timeago.dart
+++ b/timeago/lib/src/timeago.dart
@@ -19,7 +19,6 @@ Map<String, LookupMessages> _lookupMessagesMap = {
 /// setDefaultLocale('fr');
 /// ```
 void setDefaultLocale(String locale) {
-  assert(locale != null, '[locale] must not be null');
   assert(_lookupMessagesMap.containsKey(locale),
       '[locale] must be a registered locale');
   _default = locale;
@@ -37,8 +36,6 @@ void setDefaultLocale(String locale) {
 /// with the desired messages
 ///
 void setLocaleMessages(String locale, LookupMessages lookupMessages) {
-  assert(locale != null, '[locale] must not be null');
-  assert(lookupMessages != null, '[lookupMessages] must not be null');
   _lookupMessagesMap[locale] = lookupMessages;
 }
 
@@ -51,7 +48,7 @@ void setLocaleMessages(String locale, LookupMessages lookupMessages) {
 /// - If [allowFromNow] is passed, format will use the From prefix, ie. a date
 ///   5 minutes from now in 'en' locale will display as "5 minutes from now"
 String format(DateTime date,
-    {String locale, DateTime clock, bool allowFromNow}) {
+    {String? locale, DateTime? clock, bool? allowFromNow}) {
   final _locale = locale ?? _default;
   final _allowFromNow = allowFromNow ?? false;
   final messages = _lookupMessagesMap[_locale] ?? EnMessages();
@@ -102,6 +99,6 @@ String format(DateTime date,
   }
 
   return [prefix, result, suffix]
-      .where((str) => str != null && str.isNotEmpty)
+      .where((str) => str.isNotEmpty)
       .join(messages.wordSeparator());
 }

--- a/timeago/pubspec.yaml
+++ b/timeago/pubspec.yaml
@@ -1,15 +1,15 @@
 name: timeago
 description: >
   A library useful for creating fuzzy timestamps. (e.g. "15 minutes ago")
-version: 2.0.28
+version: 3.0.0-nullsafety.0
 homepage: https://github.com/andresaraujo/timeago.dart
 
 environment:
-  sdk: ">=2.10.0 <3.0.0"
+  sdk: '>=2.12.0-29.10.beta <3.0.0'
 
 #dependencies:
 
 dev_dependencies:
-  test: ^1.14.3
+  test: ^1.16.0-nullsafety
   build_runner: ^1.10.0
   build_web_compilers: ^2.11.0


### PR DESCRIPTION
See https://dart.dev/null-safety/migration-guide

all tests work

Edit: tests are failing on GH because this change requires the beta version of the Dart SDK. That's the reason why this change should be published as a pre-release version (See https://dart.dev/null-safety/migration-guide#package-version)