### PR TITLE
Make clock variable a function instead of a static DateTime

### DIFF
--- a/timeago_flutter/lib/timeago_flutter.dart
+++ b/timeago_flutter/lib/timeago_flutter.dart
@@ -10,7 +10,7 @@ typedef TimeagoBuilder = Widget Function(BuildContext context, String value);
 
 ///
 /// Widget that provides a fuzzy time (eg '15 minues ago') relative to the
-/// provided [date]. Builder function will get executed at a [resfreshRate] (Defaults to 1 minute)
+/// provided [date]. Builder function will get executed at a [refreshRate] (Defaults to 1 minute)
 ///
 /// Example
 ///
@@ -64,14 +64,14 @@ class Timeago extends TimerRefreshWidget {
 
   final TimeagoBuilder builder;
   final DateTime date;
-  final DateTime clock;
+  final DateTime Function() clock;
   final String locale;
   final bool allowFromNow;
 
   @override
   Widget build(BuildContext context) {
     final formatted = timeago.format(date,
-        locale: locale, clock: clock, allowFromNow: allowFromNow);
+        locale: locale, clock: clock?.call(), allowFromNow: allowFromNow);
     return builder(context, formatted);
   }
 }

--- a/timeago_flutter/test/timeago_flutter_test.dart
+++ b/timeago_flutter/test/timeago_flutter_test.dart
@@ -5,8 +5,15 @@ import 'package:timeago_flutter/timeago_flutter.dart';
 
 void main() {
   testWidgets('Timeago basic test', (WidgetTester tester) async {
-    
-    await tester.pumpWidget(Directionality(textDirection: TextDirection.ltr, child: Timeago(date: DateTime.now(), builder: (_, value) => Text(value) )));
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: Timeago(
+          date: DateTime.now(),
+          builder: (_, value) => Text(value),
+        ),
+      ),
+    );
 
     final valueFinder = find.byType(Text);
     final textFinder = find.text('a moment ago');
@@ -17,7 +24,16 @@ void main() {
 
   testWidgets('Timeago 10 minutes ago', (WidgetTester tester) async {
     final now = DateTime.now();
-    await tester.pumpWidget(Directionality(textDirection: TextDirection.ltr, child: Timeago(date: now.subtract(Duration(minutes: 10)), clock: now, builder: (_, value) => Text(value) )));
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: Timeago(
+          date: now.subtract(Duration(minutes: 10)),
+          clock: () => now,
+          builder: (_, value) => Text(value),
+        ),
+      ),
+    );
 
     final valueFinder = find.byType(Text);
     final textFinder = find.text('10 minutes ago');
@@ -28,7 +44,17 @@ void main() {
 
   testWidgets('Timeago locale', (WidgetTester tester) async {
     final now = DateTime.now();
-    await tester.pumpWidget(Directionality(textDirection: TextDirection.ltr, child: Timeago(date: now, clock: now, locale: 'es', builder: (_, value) => Text(value) )));
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: Timeago(
+          date: now,
+          clock: () => now,
+          locale: 'es',
+          builder: (_, value) => Text(value),
+        ),
+      ),
+    );
 
     final valueFinder = find.byType(Text);
     final textFinder = find.text('hace un momento');


### PR DESCRIPTION
This makes the API more elastic as allowing passing only a static value to `clock` makes the component show the same text on every refresh. My case is that I use an injected `Clock` instance across the whole app for testability, but I still want the `Timeago` widget to refresh itself automatically with regard to the current time (provided by my `Clock`).

This is unfortunately a breaking change. I'm happy to discuss other API options. We could add a second property like `getClock` for example to achieve backwards compatibility with an assert that would allow only one of the properties `clock` or `getClock` to be specified.