### PR TITLE
Fix typo in docs and tests formatting

### DIFF
--- a/timeago_flutter/lib/timeago_flutter.dart
+++ b/timeago_flutter/lib/timeago_flutter.dart
@@ -10,7 +10,7 @@ typedef TimeagoBuilder = Widget Function(BuildContext context, String value);
 
 ///
 /// Widget that provides a fuzzy time (eg '15 minues ago') relative to the
-/// provided [date]. Builder function will get executed at a [resfreshRate] (Defaults to 1 minute)
+/// provided [date]. Builder function will get executed at a [refreshRate] (Defaults to 1 minute)
 ///
 /// Example
 ///

--- a/timeago_flutter/test/timeago_flutter_test.dart
+++ b/timeago_flutter/test/timeago_flutter_test.dart
@@ -5,8 +5,15 @@ import 'package:timeago_flutter/timeago_flutter.dart';
 
 void main() {
   testWidgets('Timeago basic test', (WidgetTester tester) async {
-    
-    await tester.pumpWidget(Directionality(textDirection: TextDirection.ltr, child: Timeago(date: DateTime.now(), builder: (_, value) => Text(value) )));
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: Timeago(
+          date: DateTime.now(),
+          builder: (_, value) => Text(value),
+        ),
+      ),
+    );
 
     final valueFinder = find.byType(Text);
     final textFinder = find.text('a moment ago');
@@ -17,7 +24,16 @@ void main() {
 
   testWidgets('Timeago 10 minutes ago', (WidgetTester tester) async {
     final now = DateTime.now();
-    await tester.pumpWidget(Directionality(textDirection: TextDirection.ltr, child: Timeago(date: now.subtract(Duration(minutes: 10)), clock: now, builder: (_, value) => Text(value) )));
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: Timeago(
+          date: now.subtract(Duration(minutes: 10)),
+          clock: now,
+          builder: (_, value) => Text(value),
+        ),
+      ),
+    );
 
     final valueFinder = find.byType(Text);
     final textFinder = find.text('10 minutes ago');
@@ -28,7 +44,17 @@ void main() {
 
   testWidgets('Timeago locale', (WidgetTester tester) async {
     final now = DateTime.now();
-    await tester.pumpWidget(Directionality(textDirection: TextDirection.ltr, child: Timeago(date: now, clock: now, locale: 'es', builder: (_, value) => Text(value) )));
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: Timeago(
+          date: now,
+          clock: now,
+          locale: 'es',
+          builder: (_, value) => Text(value),
+        ),
+      ),
+    );
 
     final valueFinder = find.byType(Text);
     final textFinder = find.text('hace un momento');


### PR DESCRIPTION
- Fixes a typo in docs
- Adjusts code formatting for tests so that it's compatible with `dartfmt` and more readable