### PR TITLE
Make en_short consistent with other sites

### DIFF
--- a/timeago/lib/src/messages/en_messages.dart
+++ b/timeago/lib/src/messages/en_messages.dart
@@ -49,25 +49,25 @@ class EnShortMessages implements LookupMessages {
   @override
   String lessThanOneMinute(int seconds) => 'now';
   @override
-  String aboutAMinute(int minutes) => '1 min';
+  String aboutAMinute(int minutes) => '1m';
   @override
-  String minutes(int minutes) => '$minutes min';
+  String minutes(int minutes) => '${minutes}m';
   @override
-  String aboutAnHour(int minutes) => '~1 h';
+  String aboutAnHour(int minutes) => '~1h';
   @override
-  String hours(int hours) => '$hours h';
+  String hours(int hours) => '${hours}h';
   @override
-  String aDay(int hours) => '~1 d';
+  String aDay(int hours) => '~1d';
   @override
-  String days(int days) => '$days d';
+  String days(int days) => '${days}d';
   @override
-  String aboutAMonth(int days) => '~1 mo';
+  String aboutAMonth(int days) => '~1mo';
   @override
-  String months(int months) => '$months mo';
+  String months(int months) => '${months}mo';
   @override
-  String aboutAYear(int year) => '~1 yr';
+  String aboutAYear(int year) => '~1y';
   @override
-  String years(int years) => '$years yr';
+  String years(int years) => '${years}y';
   @override
   String wordSeparator() => ' ';
 }

--- a/timeago/test/all_test.dart
+++ b/timeago/test/all_test.dart
@@ -54,7 +54,7 @@ void main() {
 
       // use 'en_short'
       var result = timeago.format(now, locale: 'en_short', clock: clock);
-      expect(result, equals('3 min'));
+      expect(result, equals('3m'));
     });
 
     test('should allow from now dates', () async {


### PR DESCRIPTION
This applies three changes to en_short:

1. Removes spaces between numbers and units, so that "1 h" becomes "1h"
2. Shortens "min" to "m", so that "1 min" becomes "1m" (month remains as "mo")
2. Shortens "yr" to "y", so that "1 yr" becomes "1y"

I made these changes because this is what I've witnessed to be the standard on the rest of internet:

Facebook:
![facebook](https://user-images.githubusercontent.com/438911/103156824-c48e6c00-4761-11eb-9910-9d38e5883687.png)

Twitter:
![twitter](https://user-images.githubusercontent.com/438911/103156847-f8699180-4761-11eb-8ff5-5767790cb6db.png)

LinkedIn:
![linkedin](https://user-images.githubusercontent.com/438911/103156826-c5bf9900-4761-11eb-9346-68da333fb310.png)

Venmo:
![venmo](https://user-images.githubusercontent.com/438911/103156880-336bc500-4762-11eb-8262-ff36a9b49299.png)

Feel free to reject some or all changes if this doesn't match with the direction you want, I'll be happy to revert individual parts.