### PR TITLE
Fixing mistakes [RO]

### DIFF
--- a/timeago/lib/src/messages/ro_messages.dart
+++ b/timeago/lib/src/messages/ro_messages.dart
@@ -11,13 +11,13 @@ class RoMessages implements LookupMessages {
   @override
   String suffixFromNow() => '';
   @override
-  String lessThanOneMinute(int seconds) => 'un moment';
+  String lessThanOneMinute(int seconds) => 'o clipită';
   @override
   String aboutAMinute(int minutes) => 'un minut';
   @override
   String minutes(int minutes) => '$minutes minute';
   @override
-  String aboutAnHour(int minutes) => 'o ora';
+  String aboutAnHour(int minutes) => 'o oră';
   @override
   String hours(int hours) => '$hours ore';
   @override
@@ -53,7 +53,7 @@ class RoShortMessages implements LookupMessages {
   @override
   String minutes(int minutes) => '$minutes min';
   @override
-  String aboutAnHour(int minutes) => '~1 ora';
+  String aboutAnHour(int minutes) => '~1 oră';
   @override
   String hours(int hours) => '$hours ore';
   @override


### PR DESCRIPTION
'ora' is the definitive of 'oră' - hour, and effectively translates to 'the hour'. It's incorrect to say 'o ora' because the definiteness doesn't match. It's comparable to saying 'an the hour' in English.