### PR TITLE
Fixing mistakes [PL]

### DIFF
--- a/timeago/lib/src/messages/pl_messages.dart
+++ b/timeago/lib/src/messages/pl_messages.dart
@@ -13,11 +13,11 @@ class PlMessages implements LookupMessages {
   @override
   String lessThanOneMinute(int seconds) => 'chwilę';
   @override
-  String aboutAMinute(int minutes) => 'około minutę';
+  String aboutAMinute(int minutes) => 'około minuty';
   @override
   String minutes(int minutes) => _pluralize(minutes, 'minuty', 'minut');
   @override
-  String aboutAnHour(int minutes) => 'około godzinę';
+  String aboutAnHour(int minutes) => 'około godziny';
   @override
   String hours(int hours) => _pluralize(hours, 'godziny', 'godzin');
   @override
@@ -25,11 +25,11 @@ class PlMessages implements LookupMessages {
   @override
   String days(int days) => '$days dni';
   @override
-  String aboutAMonth(int days) => 'około miesiąc';
+  String aboutAMonth(int days) => 'około miesiąca';
   @override
   String months(int months) => _pluralize(months, 'miesiące', 'miesięcy');
   @override
-  String aboutAYear(int year) => 'około rok';
+  String aboutAYear(int year) => 'około roku';
   @override
   String years(int years) => _pluralize(years, 'lata', 'lat');
   @override


### PR DESCRIPTION
'około' takes the genitive form of a noun, not the accusative, and temu follows the words instead of preceding, so the case change stays. We should be saying 'około minuty temu', 'około godziny temu', 'około miesiąca temu' or 'około roku temu'.