### PR TITLE
Add locale mapping keyword for Korean

### DIFF
--- a/timeago/lib/src/timeago.dart
+++ b/timeago/lib/src/timeago.dart
@@ -10,7 +10,7 @@ Map<String, LookupMessages> _lookupMessagesMap = {
   'en_short': EnShortMessages(),
   'es': EsMessages(),
   'es_short': EsShortMessages(),
-  'ko': KoShortMessages(),
+  'ko': KoMessages(),
 };
 
 /// Sets the default [locale]. By default it is `en`.

--- a/timeago/lib/src/timeago.dart
+++ b/timeago/lib/src/timeago.dart
@@ -1,5 +1,6 @@
 import 'package:timeago/src/messages/en_messages.dart';
 import 'package:timeago/src/messages/es_messages.dart';
+import 'package:timeago/src/messages/ko_messages.dart';
 import 'package:timeago/src/messages/lookupmessages.dart';
 
 String _default = 'en';
@@ -9,6 +10,7 @@ Map<String, LookupMessages> _lookupMessagesMap = {
   'en_short': EnShortMessages(),
   'es': EsMessages(),
   'es_short': EsShortMessages(),
+  'ko': KoShortMessages(),
 };
 
 /// Sets the default [locale]. By default it is `en`.


### PR DESCRIPTION
I have got a problem changing the locale to 'ko' cause the keyword was not mapped at the _lookupMessageMap list.