### PR TITLE
#75 elapsed calculation for utc resolved

### DIFF
--- a/timeago/lib/src/timeago.dart
+++ b/timeago/lib/src/timeago.dart
@@ -53,7 +53,7 @@ String format(DateTime date,
   final _allowFromNow = allowFromNow;
   final messages = _lookupMessagesMap[_locale] ?? EnMessages();
   final _clock = clock ?? DateTime.now();
-  var elapsed = _clock.millisecondsSinceEpoch - date.millisecondsSinceEpoch;
+  var elapsed = (_clock.millisecondsSinceEpoch + _clock.timeZoneOffset.inMilliseconds) - (date.millisecondsSinceEpoch + date.timeZoneOffset.inMilliseconds);
 
   String prefix, suffix;
 


### PR DESCRIPTION
issue #75 caused because "millisecondsSinceEpoch" is "The number of milliseconds since the "Unix epoch" 1970-01-01T00:00:00Z (**UTC**)" so comparing two datetimes with different timezones must include "timeZoneOffset" in "millisecondsSinceEpoch" calculation in both "_clock" and "date" parts.