### PR TITLE
Correct dutch translation for 'hours'

### DIFF
--- a/timeago/lib/src/messages/nl_messages.dart
+++ b/timeago/lib/src/messages/nl_messages.dart
@@ -19,7 +19,7 @@ class NlMessages implements LookupMessages {
   @override
   String aboutAnHour(int minutes) => 'ongeveer één uur';
   @override
-  String hours(int hours) => '$hours uren';
+  String hours(int hours) => '$hours uur';
   @override
   String aDay(int hours) => 'één dag';
   @override


### PR DESCRIPTION
See https://vrttaal.net/taaladvies-taalkwestie/uur-uren#:~:text=De%20tijdsaanduiding%20'uur'%20blijft%20(,'%20en%20'een%20paar'.&text=Na%20een%20onbepaald%20telwoord%20gebruiken%20we%20'uren'.&text=Als%20er%20een%20bijvoeglijk%20naamwoord,'uur'%20in%20het%20meervoud.