### PR TITLE
Added Estonian

### DIFF
--- a/timeago/example/index.html
+++ b/timeago/example/index.html
@@ -64,6 +64,8 @@
     <a href="#" class="locale-link">en_short</a>
     <a href="#" class="locale-link">es</a>
     <a href="#" class="locale-link">es_short</a>
+    <a href="#" class="locale-link">et</a>
+    <a href="#" class="locale-link">et_short</a>
     <a href="#" class="locale-link">fa</a>
     <a href="#" class="locale-link">fr</a>
     <a href="#" class="locale-link">fr_short</a>

--- a/timeago/example/main.dart
+++ b/timeago/example/main.dart
@@ -26,6 +26,8 @@ main() async {
   timeago.setLocaleMessages('en_short', timeago.EnShortMessages());
   timeago.setLocaleMessages('es', timeago.EsMessages());
   timeago.setLocaleMessages('es_short', timeago.EsShortMessages());
+  timeago.setLocaleMessages('et', timeago.EtMessages());
+  timeago.setLocaleMessages('et_short', timeago.EtShortMessages());
   timeago.setLocaleMessages('fa', timeago.FaMessages());
   timeago.setLocaleMessages('fr', timeago.FrMessages());
   timeago.setLocaleMessages('fr_short', timeago.FrShortMessages());

--- a/timeago/lib/src/ago_or_from_now.dart
+++ b/timeago/lib/src/ago_or_from_now.dart
@@ -1,0 +1,1 @@
+enum AgoOrFromNow { ago, fromNow }

--- a/timeago/lib/src/messages/ar_messages.dart
+++ b/timeago/lib/src/messages/ar_messages.dart
@@ -1,3 +1,4 @@
+import 'package:timeago/src/ago_or_from_now.dart';
 import 'package:timeago/src/messages/lookupmessages.dart';
 
 /// Arabic Messages
@@ -12,7 +13,7 @@ class ArMessages implements LookupMessages {
   String suffixFromNow() => '';
 
   @override
-  String lessThanOneMinute(int seconds) {
+  String lessThanOneMinute(int seconds, AgoOrFromNow _) {
     if (seconds == 1) {
       return 'ثانية واحدة';
     } else if (seconds == 2) {
@@ -24,9 +25,9 @@ class ArMessages implements LookupMessages {
     }
   }
   @override
-  String aboutAMinute(int minutes) => 'حوالي دقيقة';
+  String aboutAMinute(int minutes, AgoOrFromNow _) => 'حوالي دقيقة';
   @override
-  String minutes(int minutes) {
+  String minutes(int minutes, AgoOrFromNow _) {
     if (minutes == 1) {
       return 'دقيقة واحدة';
     } else if (minutes == 2) {
@@ -39,9 +40,9 @@ class ArMessages implements LookupMessages {
   }
 
   @override
-  String aboutAnHour(int minutes) => 'حوالي الساعة';
+  String aboutAnHour(int minutes, AgoOrFromNow _) => 'حوالي الساعة';
   @override
-  String hours(int hours) {
+  String hours(int hours, AgoOrFromNow _) {
     if (hours == 1) {
       return 'ساعة';
     } else if (hours == 2) {
@@ -54,9 +55,9 @@ class ArMessages implements LookupMessages {
   }
 
   @override
-  String aDay(int hours) => 'يوم';
+  String aDay(int hours, AgoOrFromNow _) => 'يوم';
   @override
-  String days(int days) {
+  String days(int days, AgoOrFromNow _) {
     if (days == 1) {
       return 'يوم واحد';
     } else if (days == 2) {
@@ -69,9 +70,9 @@ class ArMessages implements LookupMessages {
   }
 
   @override
-  String aboutAMonth(int days) => 'حوالي شهر';
+  String aboutAMonth(int days, AgoOrFromNow _) => 'حوالي شهر';
   @override
-  String months(int months) {
+  String months(int months, AgoOrFromNow _) {
     if (months == 1) {
       return 'منذ شهر';
     } else if (months == 2) {
@@ -85,9 +86,9 @@ class ArMessages implements LookupMessages {
   }
 
   @override
-  String aboutAYear(int year) => 'قبل سنة';
+  String aboutAYear(int year, AgoOrFromNow _) => 'قبل سنة';
   @override
-  String years(int years) {
+  String years(int years, AgoOrFromNow _) {
     if (years == 1) {
       return 'منذ سنة';
     } else if (years == 2) {
@@ -114,27 +115,27 @@ class ArShortMessages implements LookupMessages {
   @override
   String suffixFromNow() => '';
   @override
-  String lessThanOneMinute(int seconds) => '$seconds ثا';
+  String lessThanOneMinute(int seconds, AgoOrFromNow _) => '$seconds ثا';
   @override
-  String aboutAMinute(int minutes) => '~1 د';
+  String aboutAMinute(int minutes, AgoOrFromNow _) => '~1 د';
   @override
-  String minutes(int minutes) => '$minutes د';
+  String minutes(int minutes, AgoOrFromNow _) => '$minutes د';
   @override
-  String aboutAnHour(int minutes) => '~1 س';
+  String aboutAnHour(int minutes, AgoOrFromNow _) => '~1 س';
   @override
-  String hours(int hours) => '$hours س';
+  String hours(int hours, AgoOrFromNow _) => '$hours س';
   @override
-  String aDay(int hours) => '~1 ي';
+  String aDay(int hours, AgoOrFromNow _) => '~1 ي';
   @override
-  String days(int days) => '$days ي';
+  String days(int days, AgoOrFromNow _) => '$days ي';
   @override
-  String aboutAMonth(int days) => '~1 ش';
+  String aboutAMonth(int days, AgoOrFromNow _) => '~1 ش';
   @override
-  String months(int months) => '$months ش';
+  String months(int months, AgoOrFromNow _) => '$months ش';
   @override
-  String aboutAYear(int year) => '~1 س';
+  String aboutAYear(int year, AgoOrFromNow _) => '~1 س';
   @override
-  String years(int years) => '$years س';
+  String years(int years, AgoOrFromNow _) => '$years س';
   @override
   String wordSeparator() => ' ';
 }

--- a/timeago/lib/src/messages/az_messages.dart
+++ b/timeago/lib/src/messages/az_messages.dart
@@ -1,3 +1,4 @@
+import 'package:timeago/src/ago_or_from_now.dart';
 import 'package:timeago/src/messages/lookupmessages.dart';
 
 /// Azeri Messages
@@ -11,27 +12,27 @@ class AzMessages implements LookupMessages {
   @override
   String suffixFromNow() => 'indidən';
   @override
-  String lessThanOneMinute(int seconds) => 'bir dəqiqə';
+  String lessThanOneMinute(int seconds, AgoOrFromNow _) => 'bir dəqiqə';
   @override
-  String aboutAMinute(int minutes) => 'bir dəqiqə';
+  String aboutAMinute(int minutes, AgoOrFromNow _) => 'bir dəqiqə';
   @override
-  String minutes(int minutes) => '$minutes dəqiqə';
+  String minutes(int minutes, AgoOrFromNow _) => '$minutes dəqiqə';
   @override
-  String aboutAnHour(int minutes) => 'təxminən 1 saat';
+  String aboutAnHour(int minutes, AgoOrFromNow _) => 'təxminən 1 saat';
   @override
-  String hours(int hours) => '$hours saat';
+  String hours(int hours, AgoOrFromNow _) => '$hours saat';
   @override
-  String aDay(int hours) => 'bir gün';
+  String aDay(int hours, AgoOrFromNow _) => 'bir gün';
   @override
-  String days(int days) => '$days gün';
+  String days(int days, AgoOrFromNow _) => '$days gün';
   @override
-  String aboutAMonth(int days) => 'təxminən 1 ay';
+  String aboutAMonth(int days, AgoOrFromNow _) => 'təxminən 1 ay';
   @override
-  String months(int months) => '$months ay';
+  String months(int months, AgoOrFromNow _) => '$months ay';
   @override
-  String aboutAYear(int year) => 'təxminən 1 il';
+  String aboutAYear(int year, AgoOrFromNow _) => 'təxminən 1 il';
   @override
-  String years(int years) => '$years il';
+  String years(int years, AgoOrFromNow _) => '$years il';
   @override
   String wordSeparator() => ' ';
 }
@@ -47,27 +48,27 @@ class AzShortMessages implements LookupMessages {
   @override
   String suffixFromNow() => '';
   @override
-  String lessThanOneMinute(int seconds) => 'indi';
+  String lessThanOneMinute(int seconds, AgoOrFromNow _) => 'indi';
   @override
-  String aboutAMinute(int minutes) => '1 dəq';
+  String aboutAMinute(int minutes, AgoOrFromNow _) => '1 dəq';
   @override
-  String minutes(int minutes) => '$minutes dəq';
+  String minutes(int minutes, AgoOrFromNow _) => '$minutes dəq';
   @override
-  String aboutAnHour(int minutes) => '~1 s';
+  String aboutAnHour(int minutes, AgoOrFromNow _) => '~1 s';
   @override
-  String hours(int hours) => '$hours s';
+  String hours(int hours, AgoOrFromNow _) => '$hours s';
   @override
-  String aDay(int hours) => '~1 g';
+  String aDay(int hours, AgoOrFromNow _) => '~1 g';
   @override
-  String days(int days) => '$days g';
+  String days(int days, AgoOrFromNow _) => '$days g';
   @override
-  String aboutAMonth(int days) => '~1 ay';
+  String aboutAMonth(int days, AgoOrFromNow _) => '~1 ay';
   @override
-  String months(int months) => '$months ay';
+  String months(int months, AgoOrFromNow _) => '$months ay';
   @override
-  String aboutAYear(int year) => '~1 il';
+  String aboutAYear(int year, AgoOrFromNow _) => '~1 il';
   @override
-  String years(int years) => '$years il';
+  String years(int years, AgoOrFromNow _) => '$years il';
   @override
   String wordSeparator() => ' ';
 }

--- a/timeago/lib/src/messages/ca_messages.dart
+++ b/timeago/lib/src/messages/ca_messages.dart
@@ -1,3 +1,4 @@
+import 'package:timeago/src/ago_or_from_now.dart';
 import 'package:timeago/src/messages/lookupmessages.dart';
 
 /// Catalan Messages
@@ -11,27 +12,27 @@ class CaMessages implements LookupMessages {
   @override
   String suffixFromNow() => '';
   @override
-  String lessThanOneMinute(int seconds) => 'un moment';
+  String lessThanOneMinute(int seconds, AgoOrFromNow _) => 'un moment';
   @override
-  String aboutAMinute(int minutes) => 'un minut';
+  String aboutAMinute(int minutes, AgoOrFromNow _) => 'un minut';
   @override
-  String minutes(int minutes) => '$minutes minuts';
+  String minutes(int minutes, AgoOrFromNow _) => '$minutes minuts';
   @override
-  String aboutAnHour(int minutes) => 'una hora';
+  String aboutAnHour(int minutes, AgoOrFromNow _) => 'una hora';
   @override
-  String hours(int hours) => '$hours hores';
+  String hours(int hours, AgoOrFromNow _) => '$hours hores';
   @override
-  String aDay(int hours) => 'un dia';
+  String aDay(int hours, AgoOrFromNow _) => 'un dia';
   @override
-  String days(int days) => '$days dies';
+  String days(int days, AgoOrFromNow _) => '$days dies';
   @override
-  String aboutAMonth(int days) => 'un mes';
+  String aboutAMonth(int days, AgoOrFromNow _) => 'un mes';
   @override
-  String months(int months) => '$months mesos';
+  String months(int months, AgoOrFromNow _) => '$months mesos';
   @override
-  String aboutAYear(int year) => 'un any';
+  String aboutAYear(int year, AgoOrFromNow _) => 'un any';
   @override
-  String years(int years) => '$years anys';
+  String years(int years, AgoOrFromNow _) => '$years anys';
   @override
   String wordSeparator() => ' ';
 }
@@ -47,27 +48,27 @@ class CaShortMessages implements LookupMessages {
   @override
   String suffixFromNow() => '';
   @override
-  String lessThanOneMinute(int seconds) => 'ara';
+  String lessThanOneMinute(int seconds, AgoOrFromNow _) => 'ara';
   @override
-  String aboutAMinute(int minutes) => '1 min';
+  String aboutAMinute(int minutes, AgoOrFromNow _) => '1 min';
   @override
-  String minutes(int minutes) => '$minutes min';
+  String minutes(int minutes, AgoOrFromNow _) => '$minutes min';
   @override
-  String aboutAnHour(int minutes) => '~1 hr';
+  String aboutAnHour(int minutes, AgoOrFromNow _) => '~1 hr';
   @override
-  String hours(int hours) => '$hours hr';
+  String hours(int hours, AgoOrFromNow _) => '$hours hr';
   @override
-  String aDay(int hours) => '~1 dia';
+  String aDay(int hours, AgoOrFromNow _) => '~1 dia';
   @override
-  String days(int days) => '$days dies';
+  String days(int days, AgoOrFromNow _) => '$days dies';
   @override
-  String aboutAMonth(int days) => '~1 mes';
+  String aboutAMonth(int days, AgoOrFromNow _) => '~1 mes';
   @override
-  String months(int months) => '$months mesos';
+  String months(int months, AgoOrFromNow _) => '$months mesos';
   @override
-  String aboutAYear(int year) => '~1 any';
+  String aboutAYear(int year, AgoOrFromNow _) => '~1 any';
   @override
-  String years(int years) => '$years anys';
+  String years(int years, AgoOrFromNow _) => '$years anys';
   @override
   String wordSeparator() => ' ';
 }

--- a/timeago/lib/src/messages/cs_messages.dart
+++ b/timeago/lib/src/messages/cs_messages.dart
@@ -1,3 +1,4 @@
+import 'package:timeago/src/ago_or_from_now.dart';
 import 'package:timeago/src/messages/lookupmessages.dart';
 
 /// Czech Messages
@@ -11,30 +12,30 @@ class CsMessages implements LookupMessages {
   @override
   String suffixFromNow() => 'od teď';
   @override
-  String lessThanOneMinute(int seconds) => 'chvílí';
+  String lessThanOneMinute(int seconds, AgoOrFromNow _) => 'chvílí';
   @override
-  String aboutAMinute(int minutes) => 'minutou';
+  String aboutAMinute(int minutes, AgoOrFromNow _) => 'minutou';
   @override
-  String minutes(int minutes) =>
+  String minutes(int minutes, AgoOrFromNow _) =>
       _pluralize(minutes, 'minutou', 'minutami', 'minutami');
   @override
-  String aboutAnHour(int minutes) => 'hodinou';
+  String aboutAnHour(int minutes, AgoOrFromNow _) => 'hodinou';
   @override
-  String hours(int hours) =>
+  String hours(int hours, AgoOrFromNow _) =>
       _pluralize(hours, 'hodinou', 'hodinami', 'hodinami');
   @override
-  String aDay(int hours) => 'dnem';
+  String aDay(int hours, AgoOrFromNow _) => 'dnem';
   @override
-  String days(int days) => _pluralize(days, 'dnem', 'dny', 'dny');
+  String days(int days, AgoOrFromNow _) => _pluralize(days, 'dnem', 'dny', 'dny');
   @override
-  String aboutAMonth(int days) => 'měsícem';
+  String aboutAMonth(int days, AgoOrFromNow _) => 'měsícem';
   @override
-  String months(int months) =>
+  String months(int months, AgoOrFromNow _) =>
       _pluralize(months, 'měsícem', 'měsíci', 'měsíci');
   @override
-  String aboutAYear(int year) => 'rokem';
+  String aboutAYear(int year, AgoOrFromNow _) => 'rokem';
   @override
-  String years(int years) => _pluralize(years, 'rokem', 'roky', 'roky');
+  String years(int years, AgoOrFromNow _) => _pluralize(years, 'rokem', 'roky', 'roky');
   @override
   String wordSeparator() => ' ';
 }
@@ -50,27 +51,27 @@ class CsShortMessages implements LookupMessages {
   @override
   String suffixFromNow() => '';
   @override
-  String lessThanOneMinute(int seconds) => 'teď';
+  String lessThanOneMinute(int seconds, AgoOrFromNow _) => 'teď';
   @override
-  String aboutAMinute(int minutes) => '1 min';
+  String aboutAMinute(int minutes, AgoOrFromNow _) => '1 min';
   @override
-  String minutes(int minutes) => '$minutes min';
+  String minutes(int minutes, AgoOrFromNow _) => '$minutes min';
   @override
-  String aboutAnHour(int minutes) => '~1 hod';
+  String aboutAnHour(int minutes, AgoOrFromNow _) => '~1 hod';
   @override
-  String hours(int hours) => '$hours hod';
+  String hours(int hours, AgoOrFromNow _) => '$hours hod';
   @override
-  String aDay(int hours) => '~1 den';
+  String aDay(int hours, AgoOrFromNow _) => '~1 den';
   @override
-  String days(int days) => _pluralize(days, 'den', 'dny', 'dní');
+  String days(int days, AgoOrFromNow _) => _pluralize(days, 'den', 'dny', 'dní');
   @override
-  String aboutAMonth(int days) => '~1 měsíc';
+  String aboutAMonth(int days, AgoOrFromNow _) => '~1 měsíc';
   @override
-  String months(int months) => _pluralize(months, 'měsíc', 'měsíce', 'měsíců');
+  String months(int months, AgoOrFromNow _) => _pluralize(months, 'měsíc', 'měsíce', 'měsíců');
   @override
-  String aboutAYear(int year) => '~1 rok';
+  String aboutAYear(int year, AgoOrFromNow _) => '~1 rok';
   @override
-  String years(int years) => _pluralize(years, 'rok', 'roky', 'roků');
+  String years(int years, AgoOrFromNow _) => _pluralize(years, 'rok', 'roky', 'roků');
   @override
   String wordSeparator() => ' ';
 }

--- a/timeago/lib/src/messages/da_messages.dart
+++ b/timeago/lib/src/messages/da_messages.dart
@@ -1,3 +1,4 @@
+import 'package:timeago/src/ago_or_from_now.dart';
 import 'package:timeago/src/messages/lookupmessages.dart';
 
 /// Danish Messages
@@ -11,27 +12,27 @@ class DaMessages implements LookupMessages {
   @override
   String suffixFromNow() => 'fra nu';
   @override
-  String lessThanOneMinute(int seconds) => 'et øjeblik';
+  String lessThanOneMinute(int seconds, AgoOrFromNow _) => 'et øjeblik';
   @override
-  String aboutAMinute(int minutes) => 'et minut';
+  String aboutAMinute(int minutes, AgoOrFromNow _) => 'et minut';
   @override
-  String minutes(int minutes) => '$minutes minutter';
+  String minutes(int minutes, AgoOrFromNow _) => '$minutes minutter';
   @override
-  String aboutAnHour(int minutes) => 'omkring en time';
+  String aboutAnHour(int minutes, AgoOrFromNow _) => 'omkring en time';
   @override
-  String hours(int hours) => '$hours timer';
+  String hours(int hours, AgoOrFromNow _) => '$hours timer';
   @override
-  String aDay(int hours) => 'en dag';
+  String aDay(int hours, AgoOrFromNow _) => 'en dag';
   @override
-  String days(int days) => '$days dage';
+  String days(int days, AgoOrFromNow _) => '$days dage';
   @override
-  String aboutAMonth(int days) => 'omkring en måned';
+  String aboutAMonth(int days, AgoOrFromNow _) => 'omkring en måned';
   @override
-  String months(int months) => '$months måneder';
+  String months(int months, AgoOrFromNow _) => '$months måneder';
   @override
-  String aboutAYear(int year) => 'omkring et år';
+  String aboutAYear(int year, AgoOrFromNow _) => 'omkring et år';
   @override
-  String years(int years) => '$years år';
+  String years(int years, AgoOrFromNow _) => '$years år';
   @override
   String wordSeparator() => ' ';
 }
@@ -47,27 +48,27 @@ class DaShortMessages implements LookupMessages {
   @override
   String suffixFromNow() => '';
   @override
-  String lessThanOneMinute(int seconds) => 'nu';
+  String lessThanOneMinute(int seconds, AgoOrFromNow _) => 'nu';
   @override
-  String aboutAMinute(int minutes) => '1 min';
+  String aboutAMinute(int minutes, AgoOrFromNow _) => '1 min';
   @override
-  String minutes(int minutes) => '$minutes min';
+  String minutes(int minutes, AgoOrFromNow _) => '$minutes min';
   @override
-  String aboutAnHour(int minutes) => '~1 t';
+  String aboutAnHour(int minutes, AgoOrFromNow _) => '~1 t';
   @override
-  String hours(int hours) => '$hours t';
+  String hours(int hours, AgoOrFromNow _) => '$hours t';
   @override
-  String aDay(int hours) => '~1 d';
+  String aDay(int hours, AgoOrFromNow _) => '~1 d';
   @override
-  String days(int days) => '$days d';
+  String days(int days, AgoOrFromNow _) => '$days d';
   @override
-  String aboutAMonth(int days) => '~1 md';
+  String aboutAMonth(int days, AgoOrFromNow _) => '~1 md';
   @override
-  String months(int months) => '$months md';
+  String months(int months, AgoOrFromNow _) => '$months md';
   @override
-  String aboutAYear(int year) => '~1 år';
+  String aboutAYear(int year, AgoOrFromNow _) => '~1 år';
   @override
-  String years(int years) => '$years år';
+  String years(int years, AgoOrFromNow _) => '$years år';
   @override
   String wordSeparator() => ' ';
 }

--- a/timeago/lib/src/messages/de_messages.dart
+++ b/timeago/lib/src/messages/de_messages.dart
@@ -1,3 +1,4 @@
+import 'package:timeago/src/ago_or_from_now.dart';
 import 'package:timeago/src/messages/lookupmessages.dart';
 
 /// German Messages
@@ -11,27 +12,27 @@ class DeMessages implements LookupMessages {
   @override
   String suffixFromNow() => '';
   @override
-  String lessThanOneMinute(int seconds) => 'weniger als einer Minute';
+  String lessThanOneMinute(int seconds, AgoOrFromNow _) => 'weniger als einer Minute';
   @override
-  String aboutAMinute(int minutes) => 'einer Minute';
+  String aboutAMinute(int minutes, AgoOrFromNow _) => 'einer Minute';
   @override
-  String minutes(int minutes) => '$minutes Minuten';
+  String minutes(int minutes, AgoOrFromNow _) => '$minutes Minuten';
   @override
-  String aboutAnHour(int minutes) => '~1 Stunde';
+  String aboutAnHour(int minutes, AgoOrFromNow _) => '~1 Stunde';
   @override
-  String hours(int hours) => '$hours Stunden';
+  String hours(int hours, AgoOrFromNow _) => '$hours Stunden';
   @override
-  String aDay(int hours) => '~1 Tag';
+  String aDay(int hours, AgoOrFromNow _) => '~1 Tag';
   @override
-  String days(int days) => '$days Tagen';
+  String days(int days, AgoOrFromNow _) => '$days Tagen';
   @override
-  String aboutAMonth(int days) => '~1 Monat';
+  String aboutAMonth(int days, AgoOrFromNow _) => '~1 Monat';
   @override
-  String months(int months) => '$months Monaten';
+  String months(int months, AgoOrFromNow _) => '$months Monaten';
   @override
-  String aboutAYear(int year) => '~1 Jahr';
+  String aboutAYear(int year, AgoOrFromNow _) => '~1 Jahr';
   @override
-  String years(int years) => '$years Jahren';
+  String years(int years, AgoOrFromNow _) => '$years Jahren';
   @override
   String wordSeparator() => ' ';
 }
@@ -47,27 +48,27 @@ class DeShortMessages implements LookupMessages {
   @override
   String suffixFromNow() => '';
   @override
-  String lessThanOneMinute(int seconds) => 'Jetzt';
+  String lessThanOneMinute(int seconds, AgoOrFromNow _) => 'Jetzt';
   @override
-  String aboutAMinute(int minutes) => '1 Min.';
+  String aboutAMinute(int minutes, AgoOrFromNow _) => '1 Min.';
   @override
-  String minutes(int minutes) => '$minutes Min.';
+  String minutes(int minutes, AgoOrFromNow _) => '$minutes Min.';
   @override
-  String aboutAnHour(int minutes) => '~1 Std.';
+  String aboutAnHour(int minutes, AgoOrFromNow _) => '~1 Std.';
   @override
-  String hours(int hours) => '$hours Std.';
+  String hours(int hours, AgoOrFromNow _) => '$hours Std.';
   @override
-  String aDay(int hours) => '~1 Tg.';
+  String aDay(int hours, AgoOrFromNow _) => '~1 Tg.';
   @override
-  String days(int days) => '$days Tg.';
+  String days(int days, AgoOrFromNow _) => '$days Tg.';
   @override
-  String aboutAMonth(int days) => '~1 Mo.';
+  String aboutAMonth(int days, AgoOrFromNow _) => '~1 Mo.';
   @override
-  String months(int months) => '$months Mo.';
+  String months(int months, AgoOrFromNow _) => '$months Mo.';
   @override
-  String aboutAYear(int year) => '~1 Jr.';
+  String aboutAYear(int year, AgoOrFromNow _) => '~1 Jr.';
   @override
-  String years(int years) => '$years Jr.';
+  String years(int years, AgoOrFromNow _) => '$years Jr.';
   @override
   String wordSeparator() => ' ';
 }

--- a/timeago/lib/src/messages/dv_messages.dart
+++ b/timeago/lib/src/messages/dv_messages.dart
@@ -1,3 +1,4 @@
+import 'package:timeago/src/ago_or_from_now.dart';
 import 'package:timeago/src/messages/lookupmessages.dart';
 
 /// Divehi Messages
@@ -11,27 +12,27 @@ class DvMessages implements LookupMessages {
   @override
   String suffixFromNow() => 'ފަހުން';
   @override
-  String lessThanOneMinute(int seconds) => 'ހިނދުކޮޅެއް';
+  String lessThanOneMinute(int seconds, AgoOrFromNow _) => 'ހިނދުކޮޅެއް';
   @override
-  String aboutAMinute(int minutes) => 'މިނެޓެއް ހާއިރު';
+  String aboutAMinute(int minutes, AgoOrFromNow _) => 'މިނެޓެއް ހާއިރު';
   @override
-  String minutes(int minutes) => '$minutes މިނެޓު';
+  String minutes(int minutes, AgoOrFromNow _) => '$minutes މިނެޓު';
   @override
-  String aboutAnHour(int minutes) => 'ގަޑިއިރެއް ހާއިރު';
+  String aboutAnHour(int minutes, AgoOrFromNow _) => 'ގަޑިއިރެއް ހާއިރު';
   @override
-  String hours(int hours) => '$hours ގަޑިއިރު';
+  String hours(int hours, AgoOrFromNow _) => '$hours ގަޑިއިރު';
   @override
-  String aDay(int hours) => 'އެއް ދުވަސް';
+  String aDay(int hours, AgoOrFromNow _) => 'އެއް ދުވަސް';
   @override
-  String days(int days) => '$days ދުވަސް';
+  String days(int days, AgoOrFromNow _) => '$days ދުވަސް';
   @override
-  String aboutAMonth(int days) => 'މަހެއް ހާ ދުވަސް';
+  String aboutAMonth(int days, AgoOrFromNow _) => 'މަހެއް ހާ ދުވަސް';
   @override
-  String months(int months) => '$months މަސް';
+  String months(int months, AgoOrFromNow _) => '$months މަސް';
   @override
-  String aboutAYear(int year) => 'އަހަރެއް ހާ ދުވަސް';
+  String aboutAYear(int year, AgoOrFromNow _) => 'އަހަރެއް ހާ ދުވަސް';
   @override
-  String years(int years) => '$years އަހަރު';
+  String years(int years, AgoOrFromNow _) => '$years އަހަރު';
   @override
   String wordSeparator() => ' ';
 }
@@ -47,28 +48,28 @@ class DvShortMessages implements LookupMessages {
   @override
   String suffixFromNow() => '';
   @override
-  String lessThanOneMinute(int seconds) => 'މިހާރު';
+  String lessThanOneMinute(int seconds, AgoOrFromNow _) => 'މިހާރު';
   @override
-  String aboutAMinute(int minutes) => '1 މިނެޓް';
+  String aboutAMinute(int minutes, AgoOrFromNow _) => '1 މިނެޓް';
   @override
-  String minutes(int minutes) => '$minutes މިނެޓް';
+  String minutes(int minutes, AgoOrFromNow _) => '$minutes މިނެޓް';
   @override
-  String aboutAnHour(int minutes) => '~1 ގ';
+  String aboutAnHour(int minutes, AgoOrFromNow _) => '~1 ގ';
   @override
   @override
-  String hours(int hours) => '$hours ގ';
+  String hours(int hours, AgoOrFromNow _) => '$hours ގ';
   @override
-  String aDay(int hours) => '~1 ދުވަސް';
+  String aDay(int hours, AgoOrFromNow _) => '~1 ދުވަސް';
   @override
-  String days(int days) => '$days ދުވަސް';
+  String days(int days, AgoOrFromNow _) => '$days ދުވަސް';
   @override
-  String aboutAMonth(int days) => '~1 މަސް';
+  String aboutAMonth(int days, AgoOrFromNow _) => '~1 މަސް';
   @override
-  String months(int months) => '$months މަސް';
+  String months(int months, AgoOrFromNow _) => '$months މަސް';
   @override
-  String aboutAYear(int year) => '~1 އަހަރު';
+  String aboutAYear(int year, AgoOrFromNow _) => '~1 އަހަރު';
   @override
-  String years(int years) => '$years އަހަރު';
+  String years(int years, AgoOrFromNow _) => '$years އަހަރު';
   @override
   String wordSeparator() => ' ';
 }

--- a/timeago/lib/src/messages/en_messages.dart
+++ b/timeago/lib/src/messages/en_messages.dart
@@ -1,3 +1,4 @@
+import 'package:timeago/src/ago_or_from_now.dart';
 import 'package:timeago/src/messages/lookupmessages.dart';
 
 /// English Messages
@@ -11,27 +12,27 @@ class EnMessages implements LookupMessages {
   @override
   String suffixFromNow() => 'from now';
   @override
-  String lessThanOneMinute(int seconds) => 'a moment';
+  String lessThanOneMinute(int seconds, AgoOrFromNow _) => 'a moment';
   @override
-  String aboutAMinute(int minutes) => 'a minute';
+  String aboutAMinute(int minutes, AgoOrFromNow _) => 'a minute';
   @override
-  String minutes(int minutes) => '$minutes minutes';
+  String minutes(int minutes, AgoOrFromNow _) => '$minutes minutes';
   @override
-  String aboutAnHour(int minutes) => 'about an hour';
+  String aboutAnHour(int minutes, AgoOrFromNow _) => 'about an hour';
   @override
-  String hours(int hours) => '$hours hours';
+  String hours(int hours, AgoOrFromNow _) => '$hours hours';
   @override
-  String aDay(int hours) => 'a day';
+  String aDay(int hours, AgoOrFromNow _) => 'a day';
   @override
-  String days(int days) => '$days days';
+  String days(int days, AgoOrFromNow _) => '$days days';
   @override
-  String aboutAMonth(int days) => 'about a month';
+  String aboutAMonth(int days, AgoOrFromNow _) => 'about a month';
   @override
-  String months(int months) => '$months months';
+  String months(int months, AgoOrFromNow _) => '$months months';
   @override
-  String aboutAYear(int year) => 'about a year';
+  String aboutAYear(int year, AgoOrFromNow _) => 'about a year';
   @override
-  String years(int years) => '$years years';
+  String years(int years, AgoOrFromNow _) => '$years years';
   @override
   String wordSeparator() => ' ';
 }
@@ -47,27 +48,27 @@ class EnShortMessages implements LookupMessages {
   @override
   String suffixFromNow() => '';
   @override
-  String lessThanOneMinute(int seconds) => 'now';
+  String lessThanOneMinute(int seconds, AgoOrFromNow _) => 'now';
   @override
-  String aboutAMinute(int minutes) => '1m';
+  String aboutAMinute(int minutes, AgoOrFromNow _) => '1m';
   @override
-  String minutes(int minutes) => '${minutes}m';
+  String minutes(int minutes, AgoOrFromNow _) => '${minutes}m';
   @override
-  String aboutAnHour(int minutes) => '~1h';
+  String aboutAnHour(int minutes, AgoOrFromNow _) => '~1h';
   @override
-  String hours(int hours) => '${hours}h';
+  String hours(int hours, AgoOrFromNow _) => '${hours}h';
   @override
-  String aDay(int hours) => '~1d';
+  String aDay(int hours, AgoOrFromNow _) => '~1d';
   @override
-  String days(int days) => '${days}d';
+  String days(int days, AgoOrFromNow _) => '${days}d';
   @override
-  String aboutAMonth(int days) => '~1mo';
+  String aboutAMonth(int days, AgoOrFromNow _) => '~1mo';
   @override
-  String months(int months) => '${months}mo';
+  String months(int months, AgoOrFromNow _) => '${months}mo';
   @override
-  String aboutAYear(int year) => '~1y';
+  String aboutAYear(int year, AgoOrFromNow _) => '~1y';
   @override
-  String years(int years) => '${years}y';
+  String years(int years, AgoOrFromNow _) => '${years}y';
   @override
   String wordSeparator() => ' ';
 }

--- a/timeago/lib/src/messages/es_messages.dart
+++ b/timeago/lib/src/messages/es_messages.dart
@@ -1,3 +1,4 @@
+import 'package:timeago/src/ago_or_from_now.dart';
 import 'package:timeago/src/messages/lookupmessages.dart';
 
 /// Spanish Messages
@@ -11,27 +12,27 @@ class EsMessages implements LookupMessages {
   @override
   String suffixFromNow() => '';
   @override
-  String lessThanOneMinute(int seconds) => 'un momento';
+  String lessThanOneMinute(int seconds, AgoOrFromNow _) => 'un momento';
   @override
-  String aboutAMinute(int minutes) => 'un minuto';
+  String aboutAMinute(int minutes, AgoOrFromNow _) => 'un minuto';
   @override
-  String minutes(int minutes) => '$minutes minutos';
+  String minutes(int minutes, AgoOrFromNow _) => '$minutes minutos';
   @override
-  String aboutAnHour(int minutes) => 'una hora';
+  String aboutAnHour(int minutes, AgoOrFromNow _) => 'una hora';
   @override
-  String hours(int hours) => '$hours horas';
+  String hours(int hours, AgoOrFromNow _) => '$hours horas';
   @override
-  String aDay(int hours) => 'un día';
+  String aDay(int hours, AgoOrFromNow _) => 'un día';
   @override
-  String days(int days) => '$days días';
+  String days(int days, AgoOrFromNow _) => '$days días';
   @override
-  String aboutAMonth(int days) => 'un mes';
+  String aboutAMonth(int days, AgoOrFromNow _) => 'un mes';
   @override
-  String months(int months) => '$months meses';
+  String months(int months, AgoOrFromNow _) => '$months meses';
   @override
-  String aboutAYear(int year) => 'un año';
+  String aboutAYear(int year, AgoOrFromNow _) => 'un año';
   @override
-  String years(int years) => '$years años';
+  String years(int years, AgoOrFromNow _) => '$years años';
   @override
   String wordSeparator() => ' ';
 }
@@ -47,27 +48,27 @@ class EsShortMessages implements LookupMessages {
   @override
   String suffixFromNow() => '';
   @override
-  String lessThanOneMinute(int seconds) => 'ahora';
+  String lessThanOneMinute(int seconds, AgoOrFromNow _) => 'ahora';
   @override
-  String aboutAMinute(int minutes) => '1 min';
+  String aboutAMinute(int minutes, AgoOrFromNow _) => '1 min';
   @override
-  String minutes(int minutes) => '$minutes min';
+  String minutes(int minutes, AgoOrFromNow _) => '$minutes min';
   @override
-  String aboutAnHour(int minutes) => '~1 hr';
+  String aboutAnHour(int minutes, AgoOrFromNow _) => '~1 hr';
   @override
-  String hours(int hours) => '$hours hr';
+  String hours(int hours, AgoOrFromNow _) => '$hours hr';
   @override
-  String aDay(int hours) => '~1 día';
+  String aDay(int hours, AgoOrFromNow _) => '~1 día';
   @override
-  String days(int days) => '$days días';
+  String days(int days, AgoOrFromNow _) => '$days días';
   @override
-  String aboutAMonth(int days) => '~1 mes';
+  String aboutAMonth(int days, AgoOrFromNow _) => '~1 mes';
   @override
-  String months(int months) => '$months meses';
+  String months(int months, AgoOrFromNow _) => '$months meses';
   @override
-  String aboutAYear(int year) => '~1 año';
+  String aboutAYear(int year, AgoOrFromNow _) => '~1 año';
   @override
-  String years(int years) => '$years años';
+  String years(int years, AgoOrFromNow _) => '$years años';
   @override
   String wordSeparator() => ' ';
 }

--- a/timeago/lib/src/messages/et_messages.dart
+++ b/timeago/lib/src/messages/et_messages.dart
@@ -1,0 +1,176 @@
+import 'package:timeago/src/ago_or_from_now.dart';
+import 'package:timeago/src/messages/lookupmessages.dart';
+
+/// Estonian Messages
+class EtMessages implements LookupMessages {
+  @override
+  String prefixAgo() => '';
+  @override
+  String prefixFromNow() => '';
+  @override
+  String suffixAgo() => 'tagasi';
+  @override
+  String suffixFromNow() => 'pärast';
+  @override
+  String lessThanOneMinute(int seconds, AgoOrFromNow agoOrFromNow) {
+    switch(agoOrFromNow) {
+      case AgoOrFromNow.ago:
+        return 'hetk';
+      case AgoOrFromNow.fromNow:
+        return 'hetke';
+    }
+  }
+  @override
+  String aboutAMinute(int minutes, AgoOrFromNow agoOrFromNow) {
+    switch(agoOrFromNow) {
+      case AgoOrFromNow.ago:
+        return 'üks minut';
+      case AgoOrFromNow.fromNow:
+        return 'ühe minuti';
+    }
+  }
+  @override
+  String minutes(int minutes, AgoOrFromNow agoOrFromNow) {
+    switch(agoOrFromNow) {
+      case AgoOrFromNow.ago:
+        switch(minutes) {
+          case 1:
+            return '$minutes minut';
+          default:
+            return '$minutes minutit';
+        }
+      case AgoOrFromNow.fromNow:
+        return '$minutes minuti';
+    }
+  }
+  @override
+  String aboutAnHour(int minutes, AgoOrFromNow agoOrFromNow) {
+    switch(agoOrFromNow) {
+      case AgoOrFromNow.ago:
+        return 'tund aega';
+      case AgoOrFromNow.fromNow:
+        return 'tunni aja';
+    }
+  }
+  @override
+  String hours(int hours, AgoOrFromNow agoOrFromNow) {
+    switch(agoOrFromNow) {
+      case AgoOrFromNow.ago:
+        switch(hours) {
+          case 1:
+            return '$hours tund';
+          default:
+            return '$hours tundi';
+        }
+      case AgoOrFromNow.fromNow:
+        return '$hours tunni';
+    }
+  }
+  @override
+  String aDay(int hours, AgoOrFromNow agoOrFromNow) {
+    switch(agoOrFromNow) {
+      case AgoOrFromNow.ago:
+        return 'üks päev';
+      case AgoOrFromNow.fromNow:
+        return 'ühe päeva';
+    }
+  }
+  @override
+  String days(int days, AgoOrFromNow agoOrFromNow) {
+    switch(agoOrFromNow) {
+      case AgoOrFromNow.ago:
+        switch(days) {
+          case 1:
+            return '$days päev';
+          default:
+            return '$days päeva';
+        }
+      case AgoOrFromNow.fromNow:
+        return '$days päeva';
+    }
+  }
+  @override
+  String aboutAMonth(int days, AgoOrFromNow agoOrFromNow) {
+    switch(agoOrFromNow) {
+      case AgoOrFromNow.ago:
+        return 'kuu aega';
+      case AgoOrFromNow.fromNow:
+        return 'kuu aja';
+    }
+  }
+  @override
+  String months(int months, AgoOrFromNow agoOrFromNow) {
+    switch(agoOrFromNow) {
+      case AgoOrFromNow.ago:
+        switch(months) {
+          case 1:
+            return '$months kuu';
+          default:
+            return '$months kuud';
+        }
+      case AgoOrFromNow.fromNow:
+        return '$months kuu';
+    }
+  }
+  @override
+  String aboutAYear(int year, AgoOrFromNow agoOrFromNow) {
+    switch(agoOrFromNow) {
+      case AgoOrFromNow.ago:
+        return 'üks aasta';
+      case AgoOrFromNow.fromNow:
+        return 'ühe aasta';
+    }
+  }
+  @override
+  String years(int years, AgoOrFromNow agoOrFromNow) {
+    switch(agoOrFromNow) {
+      case AgoOrFromNow.ago:
+        switch(years) {
+          case 1:
+            return '$years aasta';
+          default:
+            return '$years aastat';
+        }
+      case AgoOrFromNow.fromNow:
+        return '$years aasta';
+    }
+  }
+  @override
+  String wordSeparator() => ' ';
+}
+
+/// Estonian short Messages
+class EtShortMessages implements LookupMessages {
+  @override
+  String prefixAgo() => '';
+  @override
+  String prefixFromNow() => '';
+  @override
+  String suffixAgo() => '';
+  @override
+  String suffixFromNow() => '';
+  @override
+  String lessThanOneMinute(int seconds, AgoOrFromNow _) => 'nüüd';
+  @override
+  String aboutAMinute(int minutes, AgoOrFromNow _) => '1m';
+  @override
+  String minutes(int minutes, AgoOrFromNow _) => '${minutes}m';
+  @override
+  String aboutAnHour(int minutes, AgoOrFromNow _) => '~1t';
+  @override
+  String hours(int hours, AgoOrFromNow _) => '${hours}t';
+  @override
+  String aDay(int hours, AgoOrFromNow _) => '~1p';
+  @override
+  String days(int days, AgoOrFromNow _) => '${days}p';
+  @override
+  String aboutAMonth(int days, AgoOrFromNow _) => '~1k';
+  @override
+  String months(int months, AgoOrFromNow _) => '${months}k';
+  @override
+  String aboutAYear(int year, AgoOrFromNow _) => '~1a';
+  @override
+  String years(int years, AgoOrFromNow _) => '${years}a';
+  @override
+  String wordSeparator() => ' ';
+}

--- a/timeago/lib/src/messages/fa_messages.dart
+++ b/timeago/lib/src/messages/fa_messages.dart
@@ -1,3 +1,4 @@
+import 'package:timeago/src/ago_or_from_now.dart';
 import 'package:timeago/src/messages/lookupmessages.dart';
 
 /// Farsi Messages
@@ -11,27 +12,27 @@ class FaMessages implements LookupMessages {
   @override
   String suffixFromNow() => 'بعد';
   @override
-  String lessThanOneMinute(int seconds) => 'چند لحظه';
+  String lessThanOneMinute(int seconds, AgoOrFromNow _) => 'چند لحظه';
   @override
-  String aboutAMinute(int minutes) => 'یک دقیقه';
+  String aboutAMinute(int minutes, AgoOrFromNow _) => 'یک دقیقه';
   @override
-  String minutes(int minutes) => '${minutes} دقیقه';
+  String minutes(int minutes, AgoOrFromNow _) => '${minutes} دقیقه';
   @override
-  String aboutAnHour(int minutes) => '~یک ساعت';
+  String aboutAnHour(int minutes, AgoOrFromNow _) => '~یک ساعت';
   @override
-  String hours(int hours) => '${hours} ساعت';
+  String hours(int hours, AgoOrFromNow _) => '${hours} ساعت';
   @override
-  String aDay(int hours) => '~یک روز';
+  String aDay(int hours, AgoOrFromNow _) => '~یک روز';
   @override
-  String days(int days) => '${days} روز';
+  String days(int days, AgoOrFromNow _) => '${days} روز';
   @override
-  String aboutAMonth(int days) => '~یک ماه';
+  String aboutAMonth(int days, AgoOrFromNow _) => '~یک ماه';
   @override
-  String months(int months) => '${months} ماه';
+  String months(int months, AgoOrFromNow _) => '${months} ماه';
   @override
-  String aboutAYear(int year) => '~یک سال';
+  String aboutAYear(int year, AgoOrFromNow _) => '~یک سال';
   @override
-  String years(int years) => '${years} سال';
+  String years(int years, AgoOrFromNow _) => '${years} سال';
   @override
   String wordSeparator() => ' ';
 }

--- a/timeago/lib/src/messages/fr_messages.dart
+++ b/timeago/lib/src/messages/fr_messages.dart
@@ -1,3 +1,4 @@
+import 'package:timeago/src/ago_or_from_now.dart';
 import 'package:timeago/src/messages/lookupmessages.dart';
 
 /// French messages
@@ -11,27 +12,27 @@ class FrMessages implements LookupMessages {
   @override
   String suffixFromNow() => '';
   @override
-  String lessThanOneMinute(int seconds) => "moins d'une minute";
+  String lessThanOneMinute(int seconds, AgoOrFromNow _) => "moins d'une minute";
   @override
-  String aboutAMinute(int minutes) => 'environ une minute';
+  String aboutAMinute(int minutes, AgoOrFromNow _) => 'environ une minute';
   @override
-  String minutes(int minutes) => 'environ $minutes minutes';
+  String minutes(int minutes, AgoOrFromNow _) => 'environ $minutes minutes';
   @override
-  String aboutAnHour(int minutes) => 'environ une heure';
+  String aboutAnHour(int minutes, AgoOrFromNow _) => 'environ une heure';
   @override
-  String hours(int hours) => '$hours heures';
+  String hours(int hours, AgoOrFromNow _) => '$hours heures';
   @override
-  String aDay(int hours) => 'environ un jour';
+  String aDay(int hours, AgoOrFromNow _) => 'environ un jour';
   @override
-  String days(int days) => 'environ $days jours';
+  String days(int days, AgoOrFromNow _) => 'environ $days jours';
   @override
-  String aboutAMonth(int days) => 'environ un mois';
+  String aboutAMonth(int days, AgoOrFromNow _) => 'environ un mois';
   @override
-  String months(int months) => 'environ $months mois';
+  String months(int months, AgoOrFromNow _) => 'environ $months mois';
   @override
-  String aboutAYear(int year) => 'un an';
+  String aboutAYear(int year, AgoOrFromNow _) => 'un an';
   @override
-  String years(int years) => '$years ans';
+  String years(int years, AgoOrFromNow _) => '$years ans';
   @override
   String wordSeparator() => ' ';
 }
@@ -47,27 +48,27 @@ class FrShortMessages implements LookupMessages {
   @override
   String suffixFromNow() => '';
   @override
-  String lessThanOneMinute(int seconds) => "moins d'une minute";
+  String lessThanOneMinute(int seconds, AgoOrFromNow _) => "moins d'une minute";
   @override
-  String aboutAMinute(int minutes) => 'une minute';
+  String aboutAMinute(int minutes, AgoOrFromNow _) => 'une minute';
   @override
-  String minutes(int minutes) => '$minutes minutes';
+  String minutes(int minutes, AgoOrFromNow _) => '$minutes minutes';
   @override
-  String aboutAnHour(int minutes) => 'une heure';
+  String aboutAnHour(int minutes, AgoOrFromNow _) => 'une heure';
   @override
-  String hours(int hours) => '$hours heures';
+  String hours(int hours, AgoOrFromNow _) => '$hours heures';
   @override
-  String aDay(int hours) => 'un jour';
+  String aDay(int hours, AgoOrFromNow _) => 'un jour';
   @override
-  String days(int days) => '$days jours';
+  String days(int days, AgoOrFromNow _) => '$days jours';
   @override
-  String aboutAMonth(int days) => 'un mois';
+  String aboutAMonth(int days, AgoOrFromNow _) => 'un mois';
   @override
-  String months(int months) => '$months mois';
+  String months(int months, AgoOrFromNow _) => '$months mois';
   @override
-  String aboutAYear(int year) => 'un an';
+  String aboutAYear(int year, AgoOrFromNow _) => 'un an';
   @override
-  String years(int years) => '$years ans';
+  String years(int years, AgoOrFromNow _) => '$years ans';
   @override
   String wordSeparator() => ' ';
 }

--- a/timeago/lib/src/messages/gr_messages.dart
+++ b/timeago/lib/src/messages/gr_messages.dart
@@ -1,3 +1,4 @@
+import 'package:timeago/src/ago_or_from_now.dart';
 import 'package:timeago/src/messages/lookupmessages.dart';
 
 /// Greek messages
@@ -11,27 +12,27 @@ class GrMessages implements LookupMessages {
   @override
   String suffixFromNow() => 'απο τώρα';
   @override
-  String lessThanOneMinute(int seconds) => 'μια στιγμή';
+  String lessThanOneMinute(int seconds, AgoOrFromNow _) => 'μια στιγμή';
   @override
-  String aboutAMinute(int minutes) => 'ένα λεπτό';
+  String aboutAMinute(int minutes, AgoOrFromNow _) => 'ένα λεπτό';
   @override
-  String minutes(int minutes) => '$minutes λεπτά';
+  String minutes(int minutes, AgoOrFromNow _) => '$minutes λεπτά';
   @override
-  String aboutAnHour(int minutes) => 'περίπου μια ώρα';
+  String aboutAnHour(int minutes, AgoOrFromNow _) => 'περίπου μια ώρα';
   @override
-  String hours(int hours) => '$hours ώρες';
+  String hours(int hours, AgoOrFromNow _) => '$hours ώρες';
   @override
-  String aDay(int hours) => 'μια μέρα';
+  String aDay(int hours, AgoOrFromNow _) => 'μια μέρα';
   @override
-  String days(int days) => '$days μέρες';
+  String days(int days, AgoOrFromNow _) => '$days μέρες';
   @override
-  String aboutAMonth(int days) => 'περίπου ένα μήνα';
+  String aboutAMonth(int days, AgoOrFromNow _) => 'περίπου ένα μήνα';
   @override
-  String months(int months) => '$months μήνες';
+  String months(int months, AgoOrFromNow _) => '$months μήνες';
   @override
-  String aboutAYear(int year) => 'περίπου ένα χρόνο';
+  String aboutAYear(int year, AgoOrFromNow _) => 'περίπου ένα χρόνο';
   @override
-  String years(int years) => '$years χρόνια';
+  String years(int years, AgoOrFromNow _) => '$years χρόνια';
   @override
   String wordSeparator() => ' ';
 }
@@ -47,27 +48,27 @@ class GrShortMessages implements LookupMessages {
   @override
   String suffixFromNow() => '';
   @override
-  String lessThanOneMinute(int seconds) => 'τώρα';
+  String lessThanOneMinute(int seconds, AgoOrFromNow _) => 'τώρα';
   @override
-  String aboutAMinute(int minutes) => '1 λπτ';
+  String aboutAMinute(int minutes, AgoOrFromNow _) => '1 λπτ';
   @override
-  String minutes(int minutes) => '$minutes λπτ';
+  String minutes(int minutes, AgoOrFromNow _) => '$minutes λπτ';
   @override
-  String aboutAnHour(int minutes) => '~1 ώρ';
+  String aboutAnHour(int minutes, AgoOrFromNow _) => '~1 ώρ';
   @override
-  String hours(int hours) => '$hours ώρες';
+  String hours(int hours, AgoOrFromNow _) => '$hours ώρες';
   @override
-  String aDay(int hours) => '~1 μρ';
+  String aDay(int hours, AgoOrFromNow _) => '~1 μρ';
   @override
-  String days(int days) => '$days μρς';
+  String days(int days, AgoOrFromNow _) => '$days μρς';
   @override
-  String aboutAMonth(int days) => '~1 μν';
+  String aboutAMonth(int days, AgoOrFromNow _) => '~1 μν';
   @override
-  String months(int months) => '$months μνς';
+  String months(int months, AgoOrFromNow _) => '$months μνς';
   @override
-  String aboutAYear(int year) => '~1 χρ';
+  String aboutAYear(int year, AgoOrFromNow _) => '~1 χρ';
   @override
-  String years(int years) => '$years χρ';
+  String years(int years, AgoOrFromNow _) => '$years χρ';
   @override
   String wordSeparator() => ' ';
 }

--- a/timeago/lib/src/messages/he_messages.dart
+++ b/timeago/lib/src/messages/he_messages.dart
@@ -1,3 +1,4 @@
+import 'package:timeago/src/ago_or_from_now.dart';
 import 'package:timeago/src/messages/lookupmessages.dart';
 
 /// Hebrew Messages
@@ -11,27 +12,27 @@ class HeMessages implements LookupMessages {
   @override
   String suffixFromNow() => '';
   @override
-  String lessThanOneMinute(int seconds) => 'כמה רגעים';
+  String lessThanOneMinute(int seconds, AgoOrFromNow _) => 'כמה רגעים';
   @override
-  String aboutAMinute(int minutes) => 'דקה';
+  String aboutAMinute(int minutes, AgoOrFromNow _) => 'דקה';
   @override
-  String minutes(int minutes) => '$minutes דקות';
+  String minutes(int minutes, AgoOrFromNow _) => '$minutes דקות';
   @override
-  String aboutAnHour(int minutes) => 'כשעה';
+  String aboutAnHour(int minutes, AgoOrFromNow _) => 'כשעה';
   @override
-  String hours(int hours) => '$hours שעות';
+  String hours(int hours, AgoOrFromNow _) => '$hours שעות';
   @override
-  String aDay(int hours) => 'יום';
+  String aDay(int hours, AgoOrFromNow _) => 'יום';
   @override
-  String days(int days) => '$days ימים';
+  String days(int days, AgoOrFromNow _) => '$days ימים';
   @override
-  String aboutAMonth(int days) => 'כחודש';
+  String aboutAMonth(int days, AgoOrFromNow _) => 'כחודש';
   @override
-  String months(int months) => '$months חודשים';
+  String months(int months, AgoOrFromNow _) => '$months חודשים';
   @override
-  String aboutAYear(int year) => 'כשנה';
+  String aboutAYear(int year, AgoOrFromNow _) => 'כשנה';
   @override
-  String years(int years) => '$years שנים';
+  String years(int years, AgoOrFromNow _) => '$years שנים';
   @override
   String wordSeparator() => ' ';
 }
@@ -47,27 +48,27 @@ class HeShortMessages implements LookupMessages {
   @override
   String suffixFromNow() => '';
   @override
-  String lessThanOneMinute(int seconds) => 'כעת';
+  String lessThanOneMinute(int seconds, AgoOrFromNow _) => 'כעת';
   @override
-  String aboutAMinute(int minutes) => 'דקה';
+  String aboutAMinute(int minutes, AgoOrFromNow _) => 'דקה';
   @override
-  String minutes(int minutes) => '$minutes דקות';
+  String minutes(int minutes, AgoOrFromNow _) => '$minutes דקות';
   @override
-  String aboutAnHour(int minutes) => 'כשעה';
+  String aboutAnHour(int minutes, AgoOrFromNow _) => 'כשעה';
   @override
-  String hours(int hours) => '$hours שעות';
+  String hours(int hours, AgoOrFromNow _) => '$hours שעות';
   @override
-  String aDay(int hours) => 'יום';
+  String aDay(int hours, AgoOrFromNow _) => 'יום';
   @override
-  String days(int days) => '$days ימים';
+  String days(int days, AgoOrFromNow _) => '$days ימים';
   @override
-  String aboutAMonth(int days) => 'כחודש';
+  String aboutAMonth(int days, AgoOrFromNow _) => 'כחודש';
   @override
-  String months(int months) => '$months חודשים';
+  String months(int months, AgoOrFromNow _) => '$months חודשים';
   @override
-  String aboutAYear(int year) => 'כשנה';
+  String aboutAYear(int year, AgoOrFromNow _) => 'כשנה';
   @override
-  String years(int years) => '$years שנים';
+  String years(int years, AgoOrFromNow _) => '$years שנים';
   @override
   String wordSeparator() => ' ';
 }

--- a/timeago/lib/src/messages/hi_messages.dart
+++ b/timeago/lib/src/messages/hi_messages.dart
@@ -1,3 +1,4 @@
+import 'package:timeago/src/ago_or_from_now.dart';
 import 'package:timeago/src/messages/lookupmessages.dart';
 
 /// Hindi Messages
@@ -11,27 +12,27 @@ class HiMessages implements LookupMessages {
   @override
   String suffixFromNow() => 'अब से';
   @override
-  String lessThanOneMinute(int seconds) => 'एक क्षण पहले';
+  String lessThanOneMinute(int seconds, AgoOrFromNow _) => 'एक क्षण पहले';
   @override
-  String aboutAMinute(int minutes) => 'एक मिनट पहले';
+  String aboutAMinute(int minutes, AgoOrFromNow _) => 'एक मिनट पहले';
   @override
-  String minutes(int minutes) => '$minutes मिनट';
+  String minutes(int minutes, AgoOrFromNow _) => '$minutes मिनट';
   @override
-  String aboutAnHour(int minutes) => 'करीब एक घंटा';
+  String aboutAnHour(int minutes, AgoOrFromNow _) => 'करीब एक घंटा';
   @override
-  String hours(int hours) => '$hours घंटे';
+  String hours(int hours, AgoOrFromNow _) => '$hours घंटे';
   @override
-  String aDay(int hours) => 'एक दिन पहले';
+  String aDay(int hours, AgoOrFromNow _) => 'एक दिन पहले';
   @override
-  String days(int days) => '$days दिन';
+  String days(int days, AgoOrFromNow _) => '$days दिन';
   @override
-  String aboutAMonth(int days) => 'तक़रीबन एक महीना';
+  String aboutAMonth(int days, AgoOrFromNow _) => 'तक़रीबन एक महीना';
   @override
-  String months(int months) => '$months महीने';
+  String months(int months, AgoOrFromNow _) => '$months महीने';
   @override
-  String aboutAYear(int year) => 'एक साल पहले';
+  String aboutAYear(int year, AgoOrFromNow _) => 'एक साल पहले';
   @override
-  String years(int years) => '$years वर्षों पहले';
+  String years(int years, AgoOrFromNow _) => '$years वर्षों पहले';
   @override
   String wordSeparator() => ' ';
 }
@@ -47,27 +48,27 @@ class HiShortMessages implements LookupMessages {
   @override
   String suffixFromNow() => '';
   @override
-  String lessThanOneMinute(int seconds) => 'अभी अभी';
+  String lessThanOneMinute(int seconds, AgoOrFromNow _) => 'अभी अभी';
   @override
-  String aboutAMinute(int minutes) => '1 मि';
+  String aboutAMinute(int minutes, AgoOrFromNow _) => '1 मि';
   @override
-  String minutes(int minutes) => '$minutes मि';
+  String minutes(int minutes, AgoOrFromNow _) => '$minutes मि';
   @override
-  String aboutAnHour(int minutes) => '~1 घं';
+  String aboutAnHour(int minutes, AgoOrFromNow _) => '~1 घं';
   @override
-  String hours(int hours) => '$hours घं';
+  String hours(int hours, AgoOrFromNow _) => '$hours घं';
   @override
-  String aDay(int hours) => '~1 दि';
+  String aDay(int hours, AgoOrFromNow _) => '~1 दि';
   @override
-  String days(int days) => '$days दि';
+  String days(int days, AgoOrFromNow _) => '$days दि';
   @override
-  String aboutAMonth(int days) => '~1 म';
+  String aboutAMonth(int days, AgoOrFromNow _) => '~1 म';
   @override
-  String months(int months) => '$months म';
+  String months(int months, AgoOrFromNow _) => '$months म';
   @override
-  String aboutAYear(int year) => '~1 सा';
+  String aboutAYear(int year, AgoOrFromNow _) => '~1 सा';
   @override
-  String years(int years) => '$years सा';
+  String years(int years, AgoOrFromNow _) => '$years सा';
   @override
   String wordSeparator() => ' ';
 }

--- a/timeago/lib/src/messages/id_messages.dart
+++ b/timeago/lib/src/messages/id_messages.dart
@@ -1,3 +1,4 @@
+import 'package:timeago/src/ago_or_from_now.dart';
 import 'package:timeago/src/messages/lookupmessages.dart';
 
 /// Indonesian messages
@@ -11,27 +12,27 @@ class IdMessages implements LookupMessages {
   @override
   String suffixFromNow() => 'dari sekarang';
   @override
-  String lessThanOneMinute(int seconds) => 'kurang dari semenit';
+  String lessThanOneMinute(int seconds, AgoOrFromNow _) => 'kurang dari semenit';
   @override
-  String aboutAMinute(int minutes) => 'semenit';
+  String aboutAMinute(int minutes, AgoOrFromNow _) => 'semenit';
   @override
-  String minutes(int minutes) => '$minutes menit';
+  String minutes(int minutes, AgoOrFromNow _) => '$minutes menit';
   @override
-  String aboutAnHour(int minutes) => 'sekitar sejam';
+  String aboutAnHour(int minutes, AgoOrFromNow _) => 'sekitar sejam';
   @override
-  String hours(int hours) => '$hours jam';
+  String hours(int hours, AgoOrFromNow _) => '$hours jam';
   @override
-  String aDay(int hours) => 'sehari';
+  String aDay(int hours, AgoOrFromNow _) => 'sehari';
   @override
-  String days(int days) => '$days hari';
+  String days(int days, AgoOrFromNow _) => '$days hari';
   @override
-  String aboutAMonth(int days) => 'sekitar sebulan';
+  String aboutAMonth(int days, AgoOrFromNow _) => 'sekitar sebulan';
   @override
-  String months(int months) => '$months bulan';
+  String months(int months, AgoOrFromNow _) => '$months bulan';
   @override
-  String aboutAYear(int year) => 'sekitar setahun';
+  String aboutAYear(int year, AgoOrFromNow _) => 'sekitar setahun';
   @override
-  String years(int years) => '$years tahun';
+  String years(int years, AgoOrFromNow _) => '$years tahun';
   @override
   String wordSeparator() => ' ';
 }

--- a/timeago/lib/src/messages/it_messages.dart
+++ b/timeago/lib/src/messages/it_messages.dart
@@ -1,3 +1,4 @@
+import 'package:timeago/src/ago_or_from_now.dart';
 import 'package:timeago/src/messages/lookupmessages.dart';
 
 /// Italian messages
@@ -11,27 +12,27 @@ class ItMessages implements LookupMessages {
   @override
   String suffixFromNow() => '';
   @override
-  String lessThanOneMinute(int seconds) => 'meno di un minuto';
+  String lessThanOneMinute(int seconds, AgoOrFromNow _) => 'meno di un minuto';
   @override
-  String aboutAMinute(int minutes) => 'circa un minuto';
+  String aboutAMinute(int minutes, AgoOrFromNow _) => 'circa un minuto';
   @override
-  String minutes(int minutes) => '${minutes} minuti';
+  String minutes(int minutes, AgoOrFromNow _) => '${minutes} minuti';
   @override
-  String aboutAnHour(int minutes) => "circa un'ora";
+  String aboutAnHour(int minutes, AgoOrFromNow _) => "circa un'ora";
   @override
-  String hours(int hours) => '${hours} ore';
+  String hours(int hours, AgoOrFromNow _) => '${hours} ore';
   @override
-  String aDay(int hours) => 'circa un giorno';
+  String aDay(int hours, AgoOrFromNow _) => 'circa un giorno';
   @override
-  String days(int days) => '${days} giorni';
+  String days(int days, AgoOrFromNow _) => '${days} giorni';
   @override
-  String aboutAMonth(int days) => 'circa un mese';
+  String aboutAMonth(int days, AgoOrFromNow _) => 'circa un mese';
   @override
-  String months(int months) => '${months} mesi';
+  String months(int months, AgoOrFromNow _) => '${months} mesi';
   @override
-  String aboutAYear(int year) => 'circa un anno';
+  String aboutAYear(int year, AgoOrFromNow _) => 'circa un anno';
   @override
-  String years(int years) => '${years} anni';
+  String years(int years, AgoOrFromNow _) => '${years} anni';
   @override
   String wordSeparator() => ' ';
 }
@@ -47,27 +48,27 @@ class ItShortMessages implements LookupMessages {
   @override
   String suffixFromNow() => '';
   @override
-  String lessThanOneMinute(int seconds) => 'ora';
+  String lessThanOneMinute(int seconds, AgoOrFromNow _) => 'ora';
   @override
-  String aboutAMinute(int minutes) => '1 m';
+  String aboutAMinute(int minutes, AgoOrFromNow _) => '1 m';
   @override
-  String minutes(int minutes) => '$minutes m';
+  String minutes(int minutes, AgoOrFromNow _) => '$minutes m';
   @override
-  String aboutAnHour(int minutes) => '~1 o';
+  String aboutAnHour(int minutes, AgoOrFromNow _) => '~1 o';
   @override
-  String hours(int hours) => '$hours o';
+  String hours(int hours, AgoOrFromNow _) => '$hours o';
   @override
-  String aDay(int hours) => '~1 g';
+  String aDay(int hours, AgoOrFromNow _) => '~1 g';
   @override
-  String days(int days) => '$days g';
+  String days(int days, AgoOrFromNow _) => '$days g';
   @override
-  String aboutAMonth(int days) => '~1 m';
+  String aboutAMonth(int days, AgoOrFromNow _) => '~1 m';
   @override
-  String months(int months) => '$months m';
+  String months(int months, AgoOrFromNow _) => '$months m';
   @override
-  String aboutAYear(int year) => '~1 a';
+  String aboutAYear(int year, AgoOrFromNow _) => '~1 a';
   @override
-  String years(int years) => '$years a';
+  String years(int years, AgoOrFromNow _) => '$years a';
   @override
   String wordSeparator() => ' ';
 }

--- a/timeago/lib/src/messages/ja_messages.dart
+++ b/timeago/lib/src/messages/ja_messages.dart
@@ -1,3 +1,4 @@
+import 'package:timeago/src/ago_or_from_now.dart';
 import 'package:timeago/src/messages/lookupmessages.dart';
 
 /// Japanese messages
@@ -11,27 +12,27 @@ class JaMessages implements LookupMessages {
   @override
   String suffixFromNow() => '後';
   @override
-  String lessThanOneMinute(int seconds) => '1分未満';
+  String lessThanOneMinute(int seconds, AgoOrFromNow _) => '1分未満';
   @override
-  String aboutAMinute(int minutes) => '約1分';
+  String aboutAMinute(int minutes, AgoOrFromNow _) => '約1分';
   @override
-  String minutes(int minutes) => '${minutes}分';
+  String minutes(int minutes, AgoOrFromNow _) => '${minutes}分';
   @override
-  String aboutAnHour(int minutes) => '約1時間';
+  String aboutAnHour(int minutes, AgoOrFromNow _) => '約1時間';
   @override
-  String hours(int hours) => '約${hours}時間';
+  String hours(int hours, AgoOrFromNow _) => '約${hours}時間';
   @override
-  String aDay(int hours) => '約1日';
+  String aDay(int hours, AgoOrFromNow _) => '約1日';
   @override
-  String days(int days) => '約${days}日';
+  String days(int days, AgoOrFromNow _) => '約${days}日';
   @override
-  String aboutAMonth(int days) => '約1か月';
+  String aboutAMonth(int days, AgoOrFromNow _) => '約1か月';
   @override
-  String months(int months) => '約${months}か月';
+  String months(int months, AgoOrFromNow _) => '約${months}か月';
   @override
-  String aboutAYear(int year) => '約1年';
+  String aboutAYear(int year, AgoOrFromNow _) => '約1年';
   @override
-  String years(int years) => '約${years}年';
+  String years(int years, AgoOrFromNow _) => '約${years}年';
   @override
   String wordSeparator() => '';
 }

--- a/timeago/lib/src/messages/km_messages.dart
+++ b/timeago/lib/src/messages/km_messages.dart
@@ -1,3 +1,4 @@
+import 'package:timeago/src/ago_or_from_now.dart';
 import 'package:timeago/src/messages/lookupmessages.dart';
 
 /// Cambodian messages
@@ -11,27 +12,27 @@ class KmMessages implements LookupMessages {
   @override
   String suffixFromNow() => '';
   @override
-  String lessThanOneMinute(int seconds) => 'បន្ដិច';
+  String lessThanOneMinute(int seconds, AgoOrFromNow _) => 'បន្ដិច';
   @override
-  String aboutAMinute(int minutes) => 'ប្រមាណមួយនាទី';
+  String aboutAMinute(int minutes, AgoOrFromNow _) => 'ប្រមាណមួយនាទី';
   @override
-  String minutes(int minutes) => ' $minutes នាទី';
+  String minutes(int minutes, AgoOrFromNow _) => ' $minutes នាទី';
   @override
-  String aboutAnHour(int minutes) => 'ប្រមាណមួយម៉ោង';
+  String aboutAnHour(int minutes, AgoOrFromNow _) => 'ប្រមាណមួយម៉ោង';
   @override
-  String hours(int hours) => ' $hours ម៉ោង';
+  String hours(int hours, AgoOrFromNow _) => ' $hours ម៉ោង';
   @override
-  String aDay(int hours) => 'មួយថ្ងៃ';
+  String aDay(int hours, AgoOrFromNow _) => 'មួយថ្ងៃ';
   @override
-  String days(int days) => ' $days ថ្ងៃ';
+  String days(int days, AgoOrFromNow _) => ' $days ថ្ងៃ';
   @override
-  String aboutAMonth(int days) => 'ប្រមាណមួយខែ';
+  String aboutAMonth(int days, AgoOrFromNow _) => 'ប្រមាណមួយខែ';
   @override
-  String months(int months) => ' $months ខែ';
+  String months(int months, AgoOrFromNow _) => ' $months ខែ';
   @override
-  String aboutAYear(int year) => 'ប្រមាណមួយឆ្នាំ';
+  String aboutAYear(int year, AgoOrFromNow _) => 'ប្រមាណមួយឆ្នាំ';
   @override
-  String years(int years) => ' $years ឆ្នាំ';
+  String years(int years, AgoOrFromNow _) => ' $years ឆ្នាំ';
   @override
   String wordSeparator() => '​';
 }
@@ -47,27 +48,27 @@ class KmShortMessages implements LookupMessages {
   @override
   String suffixFromNow() => '';
   @override
-  String lessThanOneMinute(int seconds) => 'មិញ';
+  String lessThanOneMinute(int seconds, AgoOrFromNow _) => 'មិញ';
   @override
-  String aboutAMinute(int minutes) => '1 ន';
+  String aboutAMinute(int minutes, AgoOrFromNow _) => '1 ន';
   @override
-  String minutes(int minutes) => '$minutes ន';
+  String minutes(int minutes, AgoOrFromNow _) => '$minutes ន';
   @override
-  String aboutAnHour(int minutes) => '~1 ម';
+  String aboutAnHour(int minutes, AgoOrFromNow _) => '~1 ម';
   @override
-  String hours(int hours) => '$hours ម';
+  String hours(int hours, AgoOrFromNow _) => '$hours ម';
   @override
-  String aDay(int hours) => '~1 ថ';
+  String aDay(int hours, AgoOrFromNow _) => '~1 ថ';
   @override
-  String days(int days) => '$days ថ';
+  String days(int days, AgoOrFromNow _) => '$days ថ';
   @override
-  String aboutAMonth(int days) => '~1 ខ';
+  String aboutAMonth(int days, AgoOrFromNow _) => '~1 ខ';
   @override
-  String months(int months) => '$months ខ';
+  String months(int months, AgoOrFromNow _) => '$months ខ';
   @override
-  String aboutAYear(int year) => '~1 ឆ';
+  String aboutAYear(int year, AgoOrFromNow _) => '~1 ឆ';
   @override
-  String years(int years) => '$years ឆ';
+  String years(int years, AgoOrFromNow _) => '$years ឆ';
   @override
   String wordSeparator() => '';
 }

--- a/timeago/lib/src/messages/ko_messages.dart
+++ b/timeago/lib/src/messages/ko_messages.dart
@@ -1,3 +1,4 @@
+import 'package:timeago/src/ago_or_from_now.dart';
 import 'package:timeago/src/messages/lookupmessages.dart';
 
 /// Korean messages
@@ -11,27 +12,27 @@ class KoMessages implements LookupMessages {
   @override
   String suffixFromNow() => '후';
   @override
-  String lessThanOneMinute(int seconds) => '방금';
+  String lessThanOneMinute(int seconds, AgoOrFromNow _) => '방금';
   @override
-  String aboutAMinute(int minutes) => '약 1분';
+  String aboutAMinute(int minutes, AgoOrFromNow _) => '약 1분';
   @override
-  String minutes(int minutes) => '${minutes} 분';
+  String minutes(int minutes, AgoOrFromNow _) => '${minutes} 분';
   @override
-  String aboutAnHour(int minutes) => '약 1시간';
+  String aboutAnHour(int minutes, AgoOrFromNow _) => '약 1시간';
   @override
-  String hours(int hours) => '${hours}시간';
+  String hours(int hours, AgoOrFromNow _) => '${hours}시간';
   @override
-  String aDay(int hours) => '약 1일';
+  String aDay(int hours, AgoOrFromNow _) => '약 1일';
   @override
-  String days(int days) => '${days}일';
+  String days(int days, AgoOrFromNow _) => '${days}일';
   @override
-  String aboutAMonth(int days) => '약 1달';
+  String aboutAMonth(int days, AgoOrFromNow _) => '약 1달';
   @override
-  String months(int months) => '${months}달';
+  String months(int months, AgoOrFromNow _) => '${months}달';
   @override
-  String aboutAYear(int year) => '약 1년';
+  String aboutAYear(int year, AgoOrFromNow _) => '약 1년';
   @override
-  String years(int years) => '${years}년';
+  String years(int years, AgoOrFromNow _) => '${years}년';
   @override
   String wordSeparator() => ' ';
 }

--- a/timeago/lib/src/messages/ku_messages.dart
+++ b/timeago/lib/src/messages/ku_messages.dart
@@ -1,3 +1,4 @@
+import 'package:timeago/src/ago_or_from_now.dart';
 import 'package:timeago/src/messages/lookupmessages.dart';
 
 /// Kurdish messages
@@ -11,11 +12,11 @@ class KuMessages implements LookupMessages {
   @override
   String suffixFromNow() => 'لە ئێستاوە';
   @override
-  String lessThanOneMinute(int seconds) => 'چەند چرکەیەک لەمەوپێش';
+  String lessThanOneMinute(int seconds, AgoOrFromNow _) => 'چەند چرکەیەک لەمەوپێش';
   @override
-  String aboutAMinute(int minutes) => 'خولەکێک لەمەوپێش';
+  String aboutAMinute(int minutes, AgoOrFromNow _) => 'خولەکێک لەمەوپێش';
   @override
-  String minutes(int minutes) {
+  String minutes(int minutes, AgoOrFromNow _) {
     if (minutes == 1) {
       return 'خولەکێک لەمەوپێش';
     }
@@ -24,9 +25,9 @@ class KuMessages implements LookupMessages {
   }
 
   @override
-  String aboutAnHour(int minutes) => 'کاژێرێک لەمەوپێش';
+  String aboutAnHour(int minutes, AgoOrFromNow _) => 'کاژێرێک لەمەوپێش';
   @override
-  String hours(int hours) {
+  String hours(int hours, AgoOrFromNow _) {
     if (hours == 1) {
       return 'کاژێرێک لەمەوپێش';
     }
@@ -35,9 +36,9 @@ class KuMessages implements LookupMessages {
   }
 
   @override
-  String aDay(int hours) => 'ڕۆژێک لەمەوپێش';
+  String aDay(int hours, AgoOrFromNow _) => 'ڕۆژێک لەمەوپێش';
   @override
-  String days(int days) {
+  String days(int days, AgoOrFromNow _) {
     if (days == 1) {
       return 'ڕۆژێک لەمەوپێش';
     }
@@ -46,9 +47,9 @@ class KuMessages implements LookupMessages {
   }
 
   @override
-  String aboutAMonth(int days) => 'مانگێک لەمەوپێش';
+  String aboutAMonth(int days, AgoOrFromNow _) => 'مانگێک لەمەوپێش';
   @override
-  String months(int months) {
+  String months(int months, AgoOrFromNow _) {
     if (months == 1) {
       return 'مانگێک لەمەوپێش';
     }
@@ -56,9 +57,9 @@ class KuMessages implements LookupMessages {
   }
 
   @override
-  String aboutAYear(int year) => 'ساڵێک لەمەوپێش';
+  String aboutAYear(int year, AgoOrFromNow _) => 'ساڵێک لەمەوپێش';
   @override
-  String years(int years) {
+  String years(int years, AgoOrFromNow _) {
     if (years == 1) {
       return 'ساڵێک لەمەوپێش';
     }
@@ -81,27 +82,27 @@ class KuShortMessages implements LookupMessages {
   @override
   String suffixFromNow() => '';
   @override
-  String lessThanOneMinute(int seconds) => 'ئێستا';
+  String lessThanOneMinute(int seconds, AgoOrFromNow _) => 'ئێستا';
   @override
-  String aboutAMinute(int minutes) => '1 خولەک';
+  String aboutAMinute(int minutes, AgoOrFromNow _) => '1 خولەک';
   @override
-  String minutes(int minutes) => 'خولەک $minutes';
+  String minutes(int minutes, AgoOrFromNow _) => 'خولەک $minutes';
   @override
-  String aboutAnHour(int minutes) => 'کاژێر ~1';
+  String aboutAnHour(int minutes, AgoOrFromNow _) => 'کاژێر ~1';
   @override
-  String hours(int hours) => 'کاژێر $hours';
+  String hours(int hours, AgoOrFromNow _) => 'کاژێر $hours';
   @override
-  String aDay(int hours) => '~1 ڕۆژ';
+  String aDay(int hours, AgoOrFromNow _) => '~1 ڕۆژ';
   @override
-  String days(int days) => 'رۆژ $days';
+  String days(int days, AgoOrFromNow _) => 'رۆژ $days';
   @override
-  String aboutAMonth(int days) => '~1 مانگ';
+  String aboutAMonth(int days, AgoOrFromNow _) => '~1 مانگ';
   @override
-  String months(int months) => 'مانگ $months';
+  String months(int months, AgoOrFromNow _) => 'مانگ $months';
   @override
-  String aboutAYear(int year) => '~1 ساڵ';
+  String aboutAYear(int year, AgoOrFromNow _) => '~1 ساڵ';
   @override
-  String years(int years) => 'ساڵ $years ';
+  String years(int years, AgoOrFromNow _) => 'ساڵ $years ';
   @override
   String wordSeparator() => ' ';
 }

--- a/timeago/lib/src/messages/lookupmessages.dart
+++ b/timeago/lib/src/messages/lookupmessages.dart
@@ -1,3 +1,5 @@
+import 'package:timeago/src/ago_or_from_now.dart';
+
 /// [LookupMessages] template for any language
 abstract class LookupMessages {
   /// Example: `prefixAgo()` 1 min `suffixAgo()`
@@ -13,37 +15,37 @@ abstract class LookupMessages {
   String suffixFromNow();
 
   /// Format when time is less than a minute
-  String lessThanOneMinute(int seconds);
+  String lessThanOneMinute(int seconds, AgoOrFromNow agoOrFromNow);
 
   /// Format when time is about a minute
-  String aboutAMinute(int minutes);
+  String aboutAMinute(int minutes, AgoOrFromNow agoOrFromNow);
 
   /// Format when time is in minutes
-  String minutes(int minutes);
+  String minutes(int minutes, AgoOrFromNow agoOrFromNow);
 
   /// Format when time is about an hour
-  String aboutAnHour(int minutes);
+  String aboutAnHour(int minutes, AgoOrFromNow agoOrFromNow);
 
   /// Format when time is in hours
-  String hours(int hours);
+  String hours(int hours, AgoOrFromNow agoOrFromNow);
 
   /// Format when time is a day
-  String aDay(int hours);
+  String aDay(int hours, AgoOrFromNow agoOrFromNow);
 
   /// Format when time is in days
-  String days(int days);
+  String days(int days, AgoOrFromNow agoOrFromNow);
 
   /// Format when time is about a month
-  String aboutAMonth(int days);
+  String aboutAMonth(int days, AgoOrFromNow agoOrFromNow);
 
   /// Format when time is in months
-  String months(int months);
+  String months(int months, AgoOrFromNow agoOrFromNow);
 
   /// Format when time is about a year
-  String aboutAYear(int year);
+  String aboutAYear(int year, AgoOrFromNow agoOrFromNow);
 
   /// Format when time is about a year
-  String years(int years);
+  String years(int years, AgoOrFromNow agoOrFromNow);
 
   /// word separator when words are concatenated
   String wordSeparator() => ' ';

--- a/timeago/lib/src/messages/mn_messages.dart
+++ b/timeago/lib/src/messages/mn_messages.dart
@@ -1,3 +1,4 @@
+import 'package:timeago/src/ago_or_from_now.dart';
 import 'package:timeago/src/messages/lookupmessages.dart';
 
 /// Mongolian Messages
@@ -11,27 +12,27 @@ class MnMessages implements LookupMessages {
   @override
   String suffixFromNow() => 'дараа';
   @override
-  String lessThanOneMinute(int seconds) => 'хэдхэн мөчийн';
+  String lessThanOneMinute(int seconds, AgoOrFromNow _) => 'хэдхэн мөчийн';
   @override
-  String aboutAMinute(int minutes) => 'минутын';
+  String aboutAMinute(int minutes, AgoOrFromNow _) => 'минутын';
   @override
-  String minutes(int minutes) => '$minutes минутын';
+  String minutes(int minutes, AgoOrFromNow _) => '$minutes минутын';
   @override
-  String aboutAnHour(int minutes) => 'цаг орчим';
+  String aboutAnHour(int minutes, AgoOrFromNow _) => 'цаг орчим';
   @override
-  String hours(int hours) => '$hours цагийн';
+  String hours(int hours, AgoOrFromNow _) => '$hours цагийн';
   @override
-  String aDay(int hours) => 'өдрийн';
+  String aDay(int hours, AgoOrFromNow _) => 'өдрийн';
   @override
-  String days(int days) => '$days өдрийн';
+  String days(int days, AgoOrFromNow _) => '$days өдрийн';
   @override
-  String aboutAMonth(int days) => 'сар орчмын';
+  String aboutAMonth(int days, AgoOrFromNow _) => 'сар орчмын';
   @override
-  String months(int months) => '$months сарын';
+  String months(int months, AgoOrFromNow _) => '$months сарын';
   @override
-  String aboutAYear(int year) => 'жил орчмын';
+  String aboutAYear(int year, AgoOrFromNow _) => 'жил орчмын';
   @override
-  String years(int years) => '$years жилийн';
+  String years(int years, AgoOrFromNow _) => '$years жилийн';
   @override
   String wordSeparator() => ' ';
 }
@@ -47,27 +48,27 @@ class MnShortMessages implements LookupMessages {
   @override
   String suffixFromNow() => '';
   @override
-  String lessThanOneMinute(int seconds) => 'саяхан';
+  String lessThanOneMinute(int seconds, AgoOrFromNow _) => 'саяхан';
   @override
-  String aboutAMinute(int minutes) => '1 мин';
+  String aboutAMinute(int minutes, AgoOrFromNow _) => '1 мин';
   @override
-  String minutes(int minutes) => '$minutes мин';
+  String minutes(int minutes, AgoOrFromNow _) => '$minutes мин';
   @override
-  String aboutAnHour(int minutes) => '~1 ц';
+  String aboutAnHour(int minutes, AgoOrFromNow _) => '~1 ц';
   @override
-  String hours(int hours) => '$hours ц';
+  String hours(int hours, AgoOrFromNow _) => '$hours ц';
   @override
-  String aDay(int hours) => '~1 ө';
+  String aDay(int hours, AgoOrFromNow _) => '~1 ө';
   @override
-  String days(int days) => '$days ө';
+  String days(int days, AgoOrFromNow _) => '$days ө';
   @override
-  String aboutAMonth(int days) => '~1 с';
+  String aboutAMonth(int days, AgoOrFromNow _) => '~1 с';
   @override
-  String months(int months) => '$months с';
+  String months(int months, AgoOrFromNow _) => '$months с';
   @override
-  String aboutAYear(int year) => '~1 ж';
+  String aboutAYear(int year, AgoOrFromNow _) => '~1 ж';
   @override
-  String years(int years) => '$years ж';
+  String years(int years, AgoOrFromNow _) => '$years ж';
   @override
   String wordSeparator() => ' ';
 }

--- a/timeago/lib/src/messages/ms_my_messages.dart
+++ b/timeago/lib/src/messages/ms_my_messages.dart
@@ -1,3 +1,4 @@
+import 'package:timeago/src/ago_or_from_now.dart';
 import 'package:timeago/src/messages/lookupmessages.dart';
 
 /// Malay-Malaysia messages
@@ -11,27 +12,27 @@ class MsMyMessages implements LookupMessages {
   @override
   String suffixFromNow() => 'dari sekarang';
   @override
-  String lessThanOneMinute(int seconds) => 'saat';
+  String lessThanOneMinute(int seconds, AgoOrFromNow _) => 'saat';
   @override
-  String aboutAMinute(int minutes) => 'seminit';
+  String aboutAMinute(int minutes, AgoOrFromNow _) => 'seminit';
   @override
-  String minutes(int minutes) => '$minutes minit';
+  String minutes(int minutes, AgoOrFromNow _) => '$minutes minit';
   @override
-  String aboutAnHour(int minutes) => 'sejam';
+  String aboutAnHour(int minutes, AgoOrFromNow _) => 'sejam';
   @override
-  String hours(int hours) => '$hours jam';
+  String hours(int hours, AgoOrFromNow _) => '$hours jam';
   @override
-  String aDay(int hours) => 'sehari';
+  String aDay(int hours, AgoOrFromNow _) => 'sehari';
   @override
-  String days(int days) => '$days hari';
+  String days(int days, AgoOrFromNow _) => '$days hari';
   @override
-  String aboutAMonth(int days) => 'sebulan';
+  String aboutAMonth(int days, AgoOrFromNow _) => 'sebulan';
   @override
-  String months(int months) => '$months bulan';
+  String months(int months, AgoOrFromNow _) => '$months bulan';
   @override
-  String aboutAYear(int year) => 'setahun';
+  String aboutAYear(int year, AgoOrFromNow _) => 'setahun';
   @override
-  String years(int years) => '$years tahun';
+  String years(int years, AgoOrFromNow _) => '$years tahun';
   @override
   String wordSeparator() => ' ';
 }
@@ -47,27 +48,27 @@ class MsMyShortMessages implements LookupMessages {
   @override
   String suffixFromNow() => '';
   @override
-  String lessThanOneMinute(int seconds) => 'sekarang';
+  String lessThanOneMinute(int seconds, AgoOrFromNow _) => 'sekarang';
   @override
-  String aboutAMinute(int minutes) => '1 min';
+  String aboutAMinute(int minutes, AgoOrFromNow _) => '1 min';
   @override
-  String minutes(int minutes) => '$minutes min';
+  String minutes(int minutes, AgoOrFromNow _) => '$minutes min';
   @override
-  String aboutAnHour(int minutes) => '~1 jam';
+  String aboutAnHour(int minutes, AgoOrFromNow _) => '~1 jam';
   @override
-  String hours(int hours) => '$hours jam';
+  String hours(int hours, AgoOrFromNow _) => '$hours jam';
   @override
-  String aDay(int hours) => '~1 hri';
+  String aDay(int hours, AgoOrFromNow _) => '~1 hri';
   @override
-  String days(int days) => '$days hri';
+  String days(int days, AgoOrFromNow _) => '$days hri';
   @override
-  String aboutAMonth(int days) => '~1 bln';
+  String aboutAMonth(int days, AgoOrFromNow _) => '~1 bln';
   @override
-  String months(int months) => '$months bln';
+  String months(int months, AgoOrFromNow _) => '$months bln';
   @override
-  String aboutAYear(int year) => '~1 thn';
+  String aboutAYear(int year, AgoOrFromNow _) => '~1 thn';
   @override
-  String years(int years) => '$years thn';
+  String years(int years, AgoOrFromNow _) => '$years thn';
   @override
   String wordSeparator() => ' ';
 }

--- a/timeago/lib/src/messages/nb_no_messages.dart
+++ b/timeago/lib/src/messages/nb_no_messages.dart
@@ -1,3 +1,4 @@
+import 'package:timeago/src/ago_or_from_now.dart';
 import 'package:timeago/src/messages/lookupmessages.dart';
 
 /// Norwegian-Bokm-Norway short messages
@@ -11,27 +12,27 @@ class NbNoShortMessages implements LookupMessages {
   @override
   String suffixFromNow() => '';
   @override
-  String lessThanOneMinute(int seconds) => 'nå';
+  String lessThanOneMinute(int seconds, AgoOrFromNow _) => 'nå';
   @override
-  String aboutAMinute(int minutes) => '1 min';
+  String aboutAMinute(int minutes, AgoOrFromNow _) => '1 min';
   @override
-  String minutes(int minutes) => '$minutes min';
+  String minutes(int minutes, AgoOrFromNow _) => '$minutes min';
   @override
-  String aboutAnHour(int minutes) => '~1 t';
+  String aboutAnHour(int minutes, AgoOrFromNow _) => '~1 t';
   @override
-  String hours(int hours) => '$hours t';
+  String hours(int hours, AgoOrFromNow _) => '$hours t';
   @override
-  String aDay(int hours) => '~1 d';
+  String aDay(int hours, AgoOrFromNow _) => '~1 d';
   @override
-  String days(int days) => '$days d';
+  String days(int days, AgoOrFromNow _) => '$days d';
   @override
-  String aboutAMonth(int days) => '~1 mnd';
+  String aboutAMonth(int days, AgoOrFromNow _) => '~1 mnd';
   @override
-  String months(int months) => '$months mnd';
+  String months(int months, AgoOrFromNow _) => '$months mnd';
   @override
-  String aboutAYear(int year) => '~1 år';
+  String aboutAYear(int year, AgoOrFromNow _) => '~1 år';
   @override
-  String years(int years) => '$years år';
+  String years(int years, AgoOrFromNow _) => '$years år';
   @override
   String wordSeparator() => ' ';
 }
@@ -47,27 +48,27 @@ class NbNoMessages implements LookupMessages {
   @override
   String suffixFromNow() => 'fra nå';
   @override
-  String lessThanOneMinute(int seconds) => 'ett øyeblikk';
+  String lessThanOneMinute(int seconds, AgoOrFromNow _) => 'ett øyeblikk';
   @override
-  String aboutAMinute(int minutes) => 'ett minutt';
+  String aboutAMinute(int minutes, AgoOrFromNow _) => 'ett minutt';
   @override
-  String minutes(int minutes) => '$minutes minutter';
+  String minutes(int minutes, AgoOrFromNow _) => '$minutes minutter';
   @override
-  String aboutAnHour(int minutes) => 'rundt en time';
+  String aboutAnHour(int minutes, AgoOrFromNow _) => 'rundt en time';
   @override
-  String hours(int hours) => '$hours timer';
+  String hours(int hours, AgoOrFromNow _) => '$hours timer';
   @override
-  String aDay(int hours) => 'en dag';
+  String aDay(int hours, AgoOrFromNow _) => 'en dag';
   @override
-  String days(int days) => '$days dager';
+  String days(int days, AgoOrFromNow _) => '$days dager';
   @override
-  String aboutAMonth(int days) => 'omtrent en måned';
+  String aboutAMonth(int days, AgoOrFromNow _) => 'omtrent en måned';
   @override
-  String months(int months) => '$months måneder';
+  String months(int months, AgoOrFromNow _) => '$months måneder';
   @override
-  String aboutAYear(int year) => 'omtrent et år';
+  String aboutAYear(int year, AgoOrFromNow _) => 'omtrent et år';
   @override
-  String years(int years) => '$years år';
+  String years(int years, AgoOrFromNow _) => '$years år';
   @override
   String wordSeparator() => ' ';
 }

--- a/timeago/lib/src/messages/nl_messages.dart
+++ b/timeago/lib/src/messages/nl_messages.dart
@@ -1,3 +1,4 @@
+import 'package:timeago/src/ago_or_from_now.dart';
 import 'package:timeago/src/messages/lookupmessages.dart';
 
 /// Dutch messages
@@ -11,27 +12,27 @@ class NlMessages implements LookupMessages {
   @override
   String suffixFromNow() => '';
   @override
-  String lessThanOneMinute(int seconds) => 'een moment';
+  String lessThanOneMinute(int seconds, AgoOrFromNow _) => 'een moment';
   @override
-  String aboutAMinute(int minutes) => 'één minuut';
+  String aboutAMinute(int minutes, AgoOrFromNow _) => 'één minuut';
   @override
-  String minutes(int minutes) => '$minutes minuten';
+  String minutes(int minutes, AgoOrFromNow _) => '$minutes minuten';
   @override
-  String aboutAnHour(int minutes) => 'ongeveer één uur';
+  String aboutAnHour(int minutes, AgoOrFromNow _) => 'ongeveer één uur';
   @override
-  String hours(int hours) => '$hours uur';
+  String hours(int hours, AgoOrFromNow _) => '$hours uur';
   @override
-  String aDay(int hours) => 'één dag';
+  String aDay(int hours, AgoOrFromNow _) => 'één dag';
   @override
-  String days(int days) => '$days dagen';
+  String days(int days, AgoOrFromNow _) => '$days dagen';
   @override
-  String aboutAMonth(int days) => 'ongeveer één maand';
+  String aboutAMonth(int days, AgoOrFromNow _) => 'ongeveer één maand';
   @override
-  String months(int months) => '$months maanden';
+  String months(int months, AgoOrFromNow _) => '$months maanden';
   @override
-  String aboutAYear(int year) => 'ongeveer één jaar';
+  String aboutAYear(int year, AgoOrFromNow _) => 'ongeveer één jaar';
   @override
-  String years(int years) => '$years jaren';
+  String years(int years, AgoOrFromNow _) => '$years jaren';
   @override
   String wordSeparator() => ' ';
 }
@@ -47,27 +48,27 @@ class NlShortMessages implements LookupMessages {
   @override
   String suffixFromNow() => '';
   @override
-  String lessThanOneMinute(int seconds) => 'nu';
+  String lessThanOneMinute(int seconds, AgoOrFromNow _) => 'nu';
   @override
-  String aboutAMinute(int minutes) => '1 min';
+  String aboutAMinute(int minutes, AgoOrFromNow _) => '1 min';
   @override
-  String minutes(int minutes) => '$minutes min';
+  String minutes(int minutes, AgoOrFromNow _) => '$minutes min';
   @override
-  String aboutAnHour(int minutes) => '~1 u';
+  String aboutAnHour(int minutes, AgoOrFromNow _) => '~1 u';
   @override
-  String hours(int hours) => '$hours u';
+  String hours(int hours, AgoOrFromNow _) => '$hours u';
   @override
-  String aDay(int hours) => '~1 d';
+  String aDay(int hours, AgoOrFromNow _) => '~1 d';
   @override
-  String days(int days) => '$days d';
+  String days(int days, AgoOrFromNow _) => '$days d';
   @override
-  String aboutAMonth(int days) => '~1 ma';
+  String aboutAMonth(int days, AgoOrFromNow _) => '~1 ma';
   @override
-  String months(int months) => '$months ma';
+  String months(int months, AgoOrFromNow _) => '$months ma';
   @override
-  String aboutAYear(int year) => '~1 jr';
+  String aboutAYear(int year, AgoOrFromNow _) => '~1 jr';
   @override
-  String years(int years) => '$years jr';
+  String years(int years, AgoOrFromNow _) => '$years jr';
   @override
   String wordSeparator() => ' ';
 }

--- a/timeago/lib/src/messages/nn_no_messages.dart
+++ b/timeago/lib/src/messages/nn_no_messages.dart
@@ -1,3 +1,4 @@
+import 'package:timeago/src/ago_or_from_now.dart';
 import 'package:timeago/src/messages/lookupmessages.dart';
 
 /// Norwegian-Nynorsk-Norway short messgages
@@ -11,27 +12,27 @@ class NnNoShortMessages implements LookupMessages {
   @override
   String suffixFromNow() => '';
   @override
-  String lessThanOneMinute(int seconds) => 'no';
+  String lessThanOneMinute(int seconds, AgoOrFromNow _) => 'no';
   @override
-  String aboutAMinute(int minutes) => '1 min';
+  String aboutAMinute(int minutes, AgoOrFromNow _) => '1 min';
   @override
-  String minutes(int minutes) => '$minutes min';
+  String minutes(int minutes, AgoOrFromNow _) => '$minutes min';
   @override
-  String aboutAnHour(int minutes) => '~1 t';
+  String aboutAnHour(int minutes, AgoOrFromNow _) => '~1 t';
   @override
-  String hours(int hours) => '$hours t';
+  String hours(int hours, AgoOrFromNow _) => '$hours t';
   @override
-  String aDay(int hours) => '~1 d';
+  String aDay(int hours, AgoOrFromNow _) => '~1 d';
   @override
-  String days(int days) => '$days d';
+  String days(int days, AgoOrFromNow _) => '$days d';
   @override
-  String aboutAMonth(int days) => '~1 mnd';
+  String aboutAMonth(int days, AgoOrFromNow _) => '~1 mnd';
   @override
-  String months(int months) => '$months mnd';
+  String months(int months, AgoOrFromNow _) => '$months mnd';
   @override
-  String aboutAYear(int year) => '~1 år';
+  String aboutAYear(int year, AgoOrFromNow _) => '~1 år';
   @override
-  String years(int years) => '$years år';
+  String years(int years, AgoOrFromNow _) => '$years år';
   @override
   String wordSeparator() => ' ';
 }
@@ -47,27 +48,27 @@ class NnNoMessages implements LookupMessages {
   @override
   String suffixFromNow() => 'frå no';
   @override
-  String lessThanOneMinute(int seconds) => 'eit augeblink';
+  String lessThanOneMinute(int seconds, AgoOrFromNow _) => 'eit augeblink';
   @override
-  String aboutAMinute(int minutes) => 'eit minutt';
+  String aboutAMinute(int minutes, AgoOrFromNow _) => 'eit minutt';
   @override
-  String minutes(int minutes) => '$minutes minutt';
+  String minutes(int minutes, AgoOrFromNow _) => '$minutes minutt';
   @override
-  String aboutAnHour(int minutes) => 'rundt ein time';
+  String aboutAnHour(int minutes, AgoOrFromNow _) => 'rundt ein time';
   @override
-  String hours(int hours) => '$hours timer';
+  String hours(int hours, AgoOrFromNow _) => '$hours timer';
   @override
-  String aDay(int hours) => 'ein dag';
+  String aDay(int hours, AgoOrFromNow _) => 'ein dag';
   @override
-  String days(int days) => '$days dagar';
+  String days(int days, AgoOrFromNow _) => '$days dagar';
   @override
-  String aboutAMonth(int days) => 'omtrent ein månad';
+  String aboutAMonth(int days, AgoOrFromNow _) => 'omtrent ein månad';
   @override
-  String months(int months) => '$months månadar';
+  String months(int months, AgoOrFromNow _) => '$months månadar';
   @override
-  String aboutAYear(int year) => 'omtrent eit år';
+  String aboutAYear(int year, AgoOrFromNow _) => 'omtrent eit år';
   @override
-  String years(int years) => '$years år';
+  String years(int years, AgoOrFromNow _) => '$years år';
   @override
   String wordSeparator() => ' ';
 }

--- a/timeago/lib/src/messages/pl_messages.dart
+++ b/timeago/lib/src/messages/pl_messages.dart
@@ -1,3 +1,4 @@
+import 'package:timeago/src/ago_or_from_now.dart';
 import 'package:timeago/src/messages/lookupmessages.dart';
 
 /// Polish messgages
@@ -11,27 +12,27 @@ class PlMessages implements LookupMessages {
   @override
   String suffixFromNow() => 'od tego momentu';
   @override
-  String lessThanOneMinute(int seconds) => 'chwilę';
+  String lessThanOneMinute(int seconds, AgoOrFromNow _) => 'chwilę';
   @override
-  String aboutAMinute(int minutes) => 'około minuty';
+  String aboutAMinute(int minutes, AgoOrFromNow _) => 'około minuty';
   @override
-  String minutes(int minutes) => _pluralize(minutes, 'minuty', 'minut');
+  String minutes(int minutes, AgoOrFromNow _) => _pluralize(minutes, 'minuty', 'minut');
   @override
-  String aboutAnHour(int minutes) => 'około godziny';
+  String aboutAnHour(int minutes, AgoOrFromNow _) => 'około godziny';
   @override
-  String hours(int hours) => _pluralize(hours, 'godziny', 'godzin');
+  String hours(int hours, AgoOrFromNow _) => _pluralize(hours, 'godziny', 'godzin');
   @override
-  String aDay(int hours) => 'dzień';
+  String aDay(int hours, AgoOrFromNow _) => 'dzień';
   @override
-  String days(int days) => '$days dni';
+  String days(int days, AgoOrFromNow _) => '$days dni';
   @override
-  String aboutAMonth(int days) => 'około miesiąca';
+  String aboutAMonth(int days, AgoOrFromNow _) => 'około miesiąca';
   @override
-  String months(int months) => _pluralize(months, 'miesiące', 'miesięcy');
+  String months(int months, AgoOrFromNow _) => _pluralize(months, 'miesiące', 'miesięcy');
   @override
-  String aboutAYear(int year) => 'około roku';
+  String aboutAYear(int year, AgoOrFromNow _) => 'około roku';
   @override
-  String years(int years) => _pluralize(years, 'lata', 'lat');
+  String years(int years, AgoOrFromNow _) => _pluralize(years, 'lata', 'lat');
   @override
   String wordSeparator() => ' ';
 

--- a/timeago/lib/src/messages/pt_br_messages.dart
+++ b/timeago/lib/src/messages/pt_br_messages.dart
@@ -1,3 +1,4 @@
+import 'package:timeago/src/ago_or_from_now.dart';
 import 'package:timeago/src/messages/lookupmessages.dart';
 
 /// Portuguese-Brazil messages
@@ -11,27 +12,27 @@ class PtBrMessages implements LookupMessages {
   @override
   String suffixFromNow() => '';
   @override
-  String lessThanOneMinute(int seconds) => 'poucos segundos';
+  String lessThanOneMinute(int seconds, AgoOrFromNow _) => 'poucos segundos';
   @override
-  String aboutAMinute(int minutes) => '1 minuto';
+  String aboutAMinute(int minutes, AgoOrFromNow _) => '1 minuto';
   @override
-  String minutes(int minutes) => '${minutes} minutos';
+  String minutes(int minutes, AgoOrFromNow _) => '${minutes} minutos';
   @override
-  String aboutAnHour(int minutes) => '1 hora';
+  String aboutAnHour(int minutes, AgoOrFromNow _) => '1 hora';
   @override
-  String hours(int hours) => '${hours} horas';
+  String hours(int hours, AgoOrFromNow _) => '${hours} horas';
   @override
-  String aDay(int hours) => '1 dia';
+  String aDay(int hours, AgoOrFromNow _) => '1 dia';
   @override
-  String days(int days) => '${days} dias';
+  String days(int days, AgoOrFromNow _) => '${days} dias';
   @override
-  String aboutAMonth(int days) => '1 mês';
+  String aboutAMonth(int days, AgoOrFromNow _) => '1 mês';
   @override
-  String months(int months) => '${months} meses';
+  String months(int months, AgoOrFromNow _) => '${months} meses';
   @override
-  String aboutAYear(int year) => '1 ano';
+  String aboutAYear(int year, AgoOrFromNow _) => '1 ano';
   @override
-  String years(int years) => '${years} anos';
+  String years(int years, AgoOrFromNow _) => '${years} anos';
   @override
   String wordSeparator() => ' ';
 }
@@ -47,27 +48,27 @@ class PtBrShortMessages implements LookupMessages {
   @override
   String suffixFromNow() => '';
   @override
-  String lessThanOneMinute(int seconds) => 'agora';
+  String lessThanOneMinute(int seconds, AgoOrFromNow _) => 'agora';
   @override
-  String aboutAMinute(int minutes) => '1 min';
+  String aboutAMinute(int minutes, AgoOrFromNow _) => '1 min';
   @override
-  String minutes(int minutes) => '${minutes} min';
+  String minutes(int minutes, AgoOrFromNow _) => '${minutes} min';
   @override
-  String aboutAnHour(int minutes) => '~1h';
+  String aboutAnHour(int minutes, AgoOrFromNow _) => '~1h';
   @override
-  String hours(int hours) => '${hours} h';
+  String hours(int hours, AgoOrFromNow _) => '${hours} h';
   @override
-  String aDay(int hours) => '~1 dia';
+  String aDay(int hours, AgoOrFromNow _) => '~1 dia';
   @override
-  String days(int days) => '${days} dias';
+  String days(int days, AgoOrFromNow _) => '${days} dias';
   @override
-  String aboutAMonth(int days) => '~1 mês';
+  String aboutAMonth(int days, AgoOrFromNow _) => '~1 mês';
   @override
-  String months(int months) => '${months} meses';
+  String months(int months, AgoOrFromNow _) => '${months} meses';
   @override
-  String aboutAYear(int year) => '~1 ano';
+  String aboutAYear(int year, AgoOrFromNow _) => '~1 ano';
   @override
-  String years(int years) => '${years} anos';
+  String years(int years, AgoOrFromNow _) => '${years} anos';
   @override
   String wordSeparator() => ' ';
 }

--- a/timeago/lib/src/messages/ro_messages.dart
+++ b/timeago/lib/src/messages/ro_messages.dart
@@ -1,3 +1,4 @@
+import 'package:timeago/src/ago_or_from_now.dart';
 import 'package:timeago/src/messages/lookupmessages.dart';
 
 /// Romanian messages
@@ -11,27 +12,27 @@ class RoMessages implements LookupMessages {
   @override
   String suffixFromNow() => '';
   @override
-  String lessThanOneMinute(int seconds) => 'o clipită';
+  String lessThanOneMinute(int seconds, AgoOrFromNow _) => 'o clipită';
   @override
-  String aboutAMinute(int minutes) => 'un minut';
+  String aboutAMinute(int minutes, AgoOrFromNow _) => 'un minut';
   @override
-  String minutes(int minutes) => '$minutes minute';
+  String minutes(int minutes, AgoOrFromNow _) => '$minutes minute';
   @override
-  String aboutAnHour(int minutes) => 'o oră';
+  String aboutAnHour(int minutes, AgoOrFromNow _) => 'o oră';
   @override
-  String hours(int hours) => '$hours ore';
+  String hours(int hours, AgoOrFromNow _) => '$hours ore';
   @override
-  String aDay(int hours) => 'o zi';
+  String aDay(int hours, AgoOrFromNow _) => 'o zi';
   @override
-  String days(int days) => '$days zile';
+  String days(int days, AgoOrFromNow _) => '$days zile';
   @override
-  String aboutAMonth(int days) => 'o luna';
+  String aboutAMonth(int days, AgoOrFromNow _) => 'o luna';
   @override
-  String months(int months) => '$months luni';
+  String months(int months, AgoOrFromNow _) => '$months luni';
   @override
-  String aboutAYear(int year) => 'un an';
+  String aboutAYear(int year, AgoOrFromNow _) => 'un an';
   @override
-  String years(int years) => '$years ani';
+  String years(int years, AgoOrFromNow _) => '$years ani';
   @override
   String wordSeparator() => ' ';
 }
@@ -47,27 +48,27 @@ class RoShortMessages implements LookupMessages {
   @override
   String suffixFromNow() => '';
   @override
-  String lessThanOneMinute(int seconds) => 'acum';
+  String lessThanOneMinute(int seconds, AgoOrFromNow _) => 'acum';
   @override
-  String aboutAMinute(int minutes) => '1 min';
+  String aboutAMinute(int minutes, AgoOrFromNow _) => '1 min';
   @override
-  String minutes(int minutes) => '$minutes min';
+  String minutes(int minutes, AgoOrFromNow _) => '$minutes min';
   @override
-  String aboutAnHour(int minutes) => '~1 oră';
+  String aboutAnHour(int minutes, AgoOrFromNow _) => '~1 oră';
   @override
-  String hours(int hours) => '$hours ore';
+  String hours(int hours, AgoOrFromNow _) => '$hours ore';
   @override
-  String aDay(int hours) => '~1 zi';
+  String aDay(int hours, AgoOrFromNow _) => '~1 zi';
   @override
-  String days(int days) => '$days zile';
+  String days(int days, AgoOrFromNow _) => '$days zile';
   @override
-  String aboutAMonth(int days) => '~1 luni';
+  String aboutAMonth(int days, AgoOrFromNow _) => '~1 luni';
   @override
-  String months(int months) => '$months luni';
+  String months(int months, AgoOrFromNow _) => '$months luni';
   @override
-  String aboutAYear(int year) => '~1 ani';
+  String aboutAYear(int year, AgoOrFromNow _) => '~1 ani';
   @override
-  String years(int years) => '$years ani';
+  String years(int years, AgoOrFromNow _) => '$years ani';
   @override
   String wordSeparator() => ' ';
 }

--- a/timeago/lib/src/messages/ru_messages.dart
+++ b/timeago/lib/src/messages/ru_messages.dart
@@ -1,3 +1,4 @@
+import 'package:timeago/src/ago_or_from_now.dart';
 import 'package:timeago/src/messages/lookupmessages.dart';
 
 /// Russian messages
@@ -11,27 +12,27 @@ class RuMessages implements LookupMessages {
   @override
   String suffixFromNow() => '';
   @override
-  String lessThanOneMinute(int seconds) => 'минуту';
+  String lessThanOneMinute(int seconds, AgoOrFromNow _) => 'минуту';
   @override
-  String aboutAMinute(int minutes) => 'минуту';
+  String aboutAMinute(int minutes, AgoOrFromNow _) => 'минуту';
   @override
-  String minutes(int minutes) => '$minutes ${_convert(minutes, 'minutes')}';
+  String minutes(int minutes, AgoOrFromNow _) => '$minutes ${_convert(minutes, 'minutes')}';
   @override
-  String aboutAnHour(int minutes) => 'час';
+  String aboutAnHour(int minutes, AgoOrFromNow _) => 'час';
   @override
-  String hours(int hours) => '$hours ${_convert(hours, 'hours')}';
+  String hours(int hours, AgoOrFromNow _) => '$hours ${_convert(hours, 'hours')}';
   @override
-  String aDay(int hours) => 'день';
+  String aDay(int hours, AgoOrFromNow _) => 'день';
   @override
-  String days(int days) => '$days ${_convert(days, 'days')}';
+  String days(int days, AgoOrFromNow _) => '$days ${_convert(days, 'days')}';
   @override
-  String aboutAMonth(int days) => 'месяц';
+  String aboutAMonth(int days, AgoOrFromNow _) => 'месяц';
   @override
-  String months(int months) => '$months ${_convert(months, 'months')}';
+  String months(int months, AgoOrFromNow _) => '$months ${_convert(months, 'months')}';
   @override
-  String aboutAYear(int year) => 'год';
+  String aboutAYear(int year, AgoOrFromNow _) => 'год';
   @override
-  String years(int years) => '$years ${_convert(years, 'years')}';
+  String years(int years, AgoOrFromNow _) => '$years ${_convert(years, 'years')}';
   @override
   String wordSeparator() => ' ';
 
@@ -98,27 +99,27 @@ class RuShortMessages implements LookupMessages {
   @override
   String suffixFromNow() => '';
   @override
-  String lessThanOneMinute(int seconds) => 'только что';
+  String lessThanOneMinute(int seconds, AgoOrFromNow _) => 'только что';
   @override
-  String aboutAMinute(int minutes) => '1 мин.';
+  String aboutAMinute(int minutes, AgoOrFromNow _) => '1 мин.';
   @override
-  String minutes(int minutes) => '$minutes мин.';
+  String minutes(int minutes, AgoOrFromNow _) => '$minutes мин.';
   @override
-  String aboutAnHour(int minutes) => '~1 ч.';
+  String aboutAnHour(int minutes, AgoOrFromNow _) => '~1 ч.';
   @override
-  String hours(int hours) => '$hours ч.';
+  String hours(int hours, AgoOrFromNow _) => '$hours ч.';
   @override
-  String aDay(int hours) => '~1 д.';
+  String aDay(int hours, AgoOrFromNow _) => '~1 д.';
   @override
-  String days(int days) => '$days д.';
+  String days(int days, AgoOrFromNow _) => '$days д.';
   @override
-  String aboutAMonth(int days) => '~1 мес.';
+  String aboutAMonth(int days, AgoOrFromNow _) => '~1 мес.';
   @override
-  String months(int months) => '$months мес.';
+  String months(int months, AgoOrFromNow _) => '$months мес.';
   @override
-  String aboutAYear(int year) => '~1 г.';
+  String aboutAYear(int year, AgoOrFromNow _) => '~1 г.';
   @override
-  String years(int years) => '$years г.';
+  String years(int years, AgoOrFromNow _) => '$years г.';
   @override
   String wordSeparator() => ' ';
 }

--- a/timeago/lib/src/messages/rw_messages.dart
+++ b/timeago/lib/src/messages/rw_messages.dart
@@ -1,3 +1,4 @@
+import 'package:timeago/src/ago_or_from_now.dart';
 import 'package:timeago/src/messages/lookupmessages.dart';
 
 /// Kinyarwanda Messages
@@ -11,27 +12,27 @@ class RwMessages implements LookupMessages {
   @override
   String suffixFromNow() => '';
   @override
-  String lessThanOneMinute(int seconds) => 'agahe gato';
+  String lessThanOneMinute(int seconds, AgoOrFromNow _) => 'agahe gato';
   @override
-  String aboutAMinute(int minutes) => 'umunota';
+  String aboutAMinute(int minutes, AgoOrFromNow _) => 'umunota';
   @override
-  String minutes(int minutes) => 'iminota $minutes';
+  String minutes(int minutes, AgoOrFromNow _) => 'iminota $minutes';
   @override
-  String aboutAnHour(int minutes) => 'isaha';
+  String aboutAnHour(int minutes, AgoOrFromNow _) => 'isaha';
   @override
-  String hours(int hours) => 'amasaha $hours';
+  String hours(int hours, AgoOrFromNow _) => 'amasaha $hours';
   @override
-  String aDay(int hours) => 'umunsi';
+  String aDay(int hours, AgoOrFromNow _) => 'umunsi';
   @override
-  String days(int days) => 'iminsi $days';
+  String days(int days, AgoOrFromNow _) => 'iminsi $days';
   @override
-  String aboutAMonth(int days) => 'ukwezi';
+  String aboutAMonth(int days, AgoOrFromNow _) => 'ukwezi';
   @override
-  String months(int months) => 'amezi $months';
+  String months(int months, AgoOrFromNow _) => 'amezi $months';
   @override
-  String aboutAYear(int year) => 'umwaka';
+  String aboutAYear(int year, AgoOrFromNow _) => 'umwaka';
   @override
-  String years(int years) => 'imyaka$years';
+  String years(int years, AgoOrFromNow _) => 'imyaka$years';
   @override
   String wordSeparator() => ' ';
 }
@@ -47,27 +48,27 @@ class RwShortMessages implements LookupMessages {
   @override
   String suffixFromNow() => '';
   @override
-  String lessThanOneMinute(int seconds) => 'ubu';
+  String lessThanOneMinute(int seconds, AgoOrFromNow _) => 'ubu';
   @override
-  String aboutAMinute(int minutes) => 'umunota';
+  String aboutAMinute(int minutes, AgoOrFromNow _) => 'umunota';
   @override
-  String minutes(int minutes) => 'iminota $minutes';
+  String minutes(int minutes, AgoOrFromNow _) => 'iminota $minutes';
   @override
-  String aboutAnHour(int minutes) => 'isaha';
+  String aboutAnHour(int minutes, AgoOrFromNow _) => 'isaha';
   @override
-  String hours(int hours) => 'amasaha $hours';
+  String hours(int hours, AgoOrFromNow _) => 'amasaha $hours';
   @override
-  String aDay(int hours) => 'umunsi';
+  String aDay(int hours, AgoOrFromNow _) => 'umunsi';
   @override
-  String days(int days) => 'iminsi $days';
+  String days(int days, AgoOrFromNow _) => 'iminsi $days';
   @override
-  String aboutAMonth(int days) => 'ukwezi';
+  String aboutAMonth(int days, AgoOrFromNow _) => 'ukwezi';
   @override
-  String months(int months) => 'amezi $months';
+  String months(int months, AgoOrFromNow _) => 'amezi $months';
   @override
-  String aboutAYear(int year) => 'umwaka';
+  String aboutAYear(int year, AgoOrFromNow _) => 'umwaka';
   @override
-  String years(int years) => 'imyaka $years';
+  String years(int years, AgoOrFromNow _) => 'imyaka $years';
   @override
   String wordSeparator() => ' ';
 }

--- a/timeago/lib/src/messages/sv_messages.dart
+++ b/timeago/lib/src/messages/sv_messages.dart
@@ -1,3 +1,4 @@
+import 'package:timeago/src/ago_or_from_now.dart';
 import 'package:timeago/src/messages/lookupmessages.dart';
 
 /// Swedish messages
@@ -11,27 +12,27 @@ class SvMessages implements LookupMessages {
   @override
   String suffixFromNow() => '';
   @override
-  String lessThanOneMinute(int seconds) => 'en stund';
+  String lessThanOneMinute(int seconds, AgoOrFromNow _) => 'en stund';
   @override
-  String aboutAMinute(int minutes) => 'en minut';
+  String aboutAMinute(int minutes, AgoOrFromNow _) => 'en minut';
   @override
-  String minutes(int minutes) => '$minutes minuter';
+  String minutes(int minutes, AgoOrFromNow _) => '$minutes minuter';
   @override
-  String aboutAnHour(int minutes) => 'ungefär en timme';
+  String aboutAnHour(int minutes, AgoOrFromNow _) => 'ungefär en timme';
   @override
-  String hours(int hours) => '$hours timmar';
+  String hours(int hours, AgoOrFromNow _) => '$hours timmar';
   @override
-  String aDay(int hours) => 'en dag';
+  String aDay(int hours, AgoOrFromNow _) => 'en dag';
   @override
-  String days(int days) => '$days dagar';
+  String days(int days, AgoOrFromNow _) => '$days dagar';
   @override
-  String aboutAMonth(int days) => 'ungefär en månad';
+  String aboutAMonth(int days, AgoOrFromNow _) => 'ungefär en månad';
   @override
-  String months(int months) => '$months månader';
+  String months(int months, AgoOrFromNow _) => '$months månader';
   @override
-  String aboutAYear(int year) => 'ungefär ett år';
+  String aboutAYear(int year, AgoOrFromNow _) => 'ungefär ett år';
   @override
-  String years(int years) => '$years år';
+  String years(int years, AgoOrFromNow _) => '$years år';
   @override
   String wordSeparator() => ' ';
 }
@@ -47,27 +48,27 @@ class SvShortMessages implements LookupMessages {
   @override
   String suffixFromNow() => '';
   @override
-  String lessThanOneMinute(int seconds) => 'nu';
+  String lessThanOneMinute(int seconds, AgoOrFromNow _) => 'nu';
   @override
-  String aboutAMinute(int minutes) => '1 min';
+  String aboutAMinute(int minutes, AgoOrFromNow _) => '1 min';
   @override
-  String minutes(int minutes) => '$minutes min';
+  String minutes(int minutes, AgoOrFromNow _) => '$minutes min';
   @override
-  String aboutAnHour(int minutes) => '~1 h';
+  String aboutAnHour(int minutes, AgoOrFromNow _) => '~1 h';
   @override
-  String hours(int hours) => '$hours h';
+  String hours(int hours, AgoOrFromNow _) => '$hours h';
   @override
-  String aDay(int hours) => '~1 d';
+  String aDay(int hours, AgoOrFromNow _) => '~1 d';
   @override
-  String days(int days) => '$days d';
+  String days(int days, AgoOrFromNow _) => '$days d';
   @override
-  String aboutAMonth(int days) => '~1 mån';
+  String aboutAMonth(int days, AgoOrFromNow _) => '~1 mån';
   @override
-  String months(int months) => '$months mån';
+  String months(int months, AgoOrFromNow _) => '$months mån';
   @override
-  String aboutAYear(int year) => '~1 år';
+  String aboutAYear(int year, AgoOrFromNow _) => '~1 år';
   @override
-  String years(int years) => '$years år';
+  String years(int years, AgoOrFromNow _) => '$years år';
   @override
   String wordSeparator() => ' ';
 }

--- a/timeago/lib/src/messages/ta_messages.dart
+++ b/timeago/lib/src/messages/ta_messages.dart
@@ -1,3 +1,4 @@
+import 'package:timeago/src/ago_or_from_now.dart';
 import 'package:timeago/src/messages/lookupmessages.dart';
 
 /// Tamil messages
@@ -11,27 +12,27 @@ class TaMessages implements LookupMessages {
   @override
   String suffixFromNow() => 'கழித்து';
   @override
-  String lessThanOneMinute(int seconds) => 'சில நொடிகள்';
+  String lessThanOneMinute(int seconds, AgoOrFromNow _) => 'சில நொடிகள்';
   @override
-  String aboutAMinute(int minutes) => 'ஒரு நிமிடம்';
+  String aboutAMinute(int minutes, AgoOrFromNow _) => 'ஒரு நிமிடம்';
   @override
-  String minutes(int minutes) => '$minutes நிமிடங்கள்';
+  String minutes(int minutes, AgoOrFromNow _) => '$minutes நிமிடங்கள்';
   @override
-  String aboutAnHour(int minutes) => 'ஓர் மணி நேரம்';
+  String aboutAnHour(int minutes, AgoOrFromNow _) => 'ஓர் மணி நேரம்';
   @override
-  String hours(int hours) => '$hours மணி நேரங்கள்';
+  String hours(int hours, AgoOrFromNow _) => '$hours மணி நேரங்கள்';
   @override
-  String aDay(int hours) => 'ஓர் நாள்';
+  String aDay(int hours, AgoOrFromNow _) => 'ஓர் நாள்';
   @override
-  String days(int days) => '$days நாட்கள்';
+  String days(int days, AgoOrFromNow _) => '$days நாட்கள்';
   @override
-  String aboutAMonth(int days) => 'ஓர் மாதம்';
+  String aboutAMonth(int days, AgoOrFromNow _) => 'ஓர் மாதம்';
   @override
-  String months(int months) => '$months மாதங்கள்';
+  String months(int months, AgoOrFromNow _) => '$months மாதங்கள்';
   @override
-  String aboutAYear(int year) => 'ஓராண்டு';
+  String aboutAYear(int year, AgoOrFromNow _) => 'ஓராண்டு';
   @override
-  String years(int years) => '$years ஆண்டுகள்';
+  String years(int years, AgoOrFromNow _) => '$years ஆண்டுகள்';
   @override
   String wordSeparator() => ' ';
 }

--- a/timeago/lib/src/messages/th_messages.dart
+++ b/timeago/lib/src/messages/th_messages.dart
@@ -1,3 +1,4 @@
+import 'package:timeago/src/ago_or_from_now.dart';
 import 'package:timeago/src/messages/lookupmessages.dart';
 
 /// Thai messages
@@ -11,27 +12,27 @@ class ThMessages implements LookupMessages {
   @override
   String suffixFromNow() => 'จากนี้';
   @override
-  String lessThanOneMinute(int seconds) => 'เมื่อครู่นี้';
+  String lessThanOneMinute(int seconds, AgoOrFromNow _) => 'เมื่อครู่นี้';
   @override
-  String aboutAMinute(int minutes) => 'ประมาณหนึ่งนาที';
+  String aboutAMinute(int minutes, AgoOrFromNow _) => 'ประมาณหนึ่งนาที';
   @override
-  String minutes(int minutes) => '$minutes นาที';
+  String minutes(int minutes, AgoOrFromNow _) => '$minutes นาที';
   @override
-  String aboutAnHour(int minutes) => 'ประมาณหนึ่งชั่วโมง';
+  String aboutAnHour(int minutes, AgoOrFromNow _) => 'ประมาณหนึ่งชั่วโมง';
   @override
-  String hours(int hours) => '$hours ชั่วโมง';
+  String hours(int hours, AgoOrFromNow _) => '$hours ชั่วโมง';
   @override
-  String aDay(int hours) => 'หนึ่งวัน';
+  String aDay(int hours, AgoOrFromNow _) => 'หนึ่งวัน';
   @override
-  String days(int days) => '$days วัน';
+  String days(int days, AgoOrFromNow _) => '$days วัน';
   @override
-  String aboutAMonth(int days) => 'ประมาณหนึ่งเดือน';
+  String aboutAMonth(int days, AgoOrFromNow _) => 'ประมาณหนึ่งเดือน';
   @override
-  String months(int months) => '$months เดือน';
+  String months(int months, AgoOrFromNow _) => '$months เดือน';
   @override
-  String aboutAYear(int year) => 'ประมาณหนึ่งปี';
+  String aboutAYear(int year, AgoOrFromNow _) => 'ประมาณหนึ่งปี';
   @override
-  String years(int years) => '$years ปี';
+  String years(int years, AgoOrFromNow _) => '$years ปี';
   @override
   String wordSeparator() => ' ';
 }
@@ -47,27 +48,27 @@ class ThShortMessages implements LookupMessages {
   @override
   String suffixFromNow() => '';
   @override
-  String lessThanOneMinute(int seconds) => 'เมื่อครู่';
+  String lessThanOneMinute(int seconds, AgoOrFromNow _) => 'เมื่อครู่';
   @override
-  String aboutAMinute(int minutes) => '1 นาที';
+  String aboutAMinute(int minutes, AgoOrFromNow _) => '1 นาที';
   @override
-  String minutes(int minutes) => '$minutes นาที';
+  String minutes(int minutes, AgoOrFromNow _) => '$minutes นาที';
   @override
-  String aboutAnHour(int minutes) => '~1 ชม';
+  String aboutAnHour(int minutes, AgoOrFromNow _) => '~1 ชม';
   @override
-  String hours(int hours) => '$hours ชม';
+  String hours(int hours, AgoOrFromNow _) => '$hours ชม';
   @override
-  String aDay(int hours) => '~1 ว';
+  String aDay(int hours, AgoOrFromNow _) => '~1 ว';
   @override
-  String days(int days) => '$days ว';
+  String days(int days, AgoOrFromNow _) => '$days ว';
   @override
-  String aboutAMonth(int days) => '~1 ด';
+  String aboutAMonth(int days, AgoOrFromNow _) => '~1 ด';
   @override
-  String months(int months) => '$months ด';
+  String months(int months, AgoOrFromNow _) => '$months ด';
   @override
-  String aboutAYear(int year) => '~1 ป';
+  String aboutAYear(int year, AgoOrFromNow _) => '~1 ป';
   @override
-  String years(int years) => '$years ป';
+  String years(int years, AgoOrFromNow _) => '$years ป';
   @override
   String wordSeparator() => ' ';
 }

--- a/timeago/lib/src/messages/tr_messages.dart
+++ b/timeago/lib/src/messages/tr_messages.dart
@@ -1,3 +1,4 @@
+import 'package:timeago/src/ago_or_from_now.dart';
 import 'package:timeago/src/messages/lookupmessages.dart';
 
 /// Turkish messages
@@ -11,27 +12,27 @@ class TrMessages implements LookupMessages {
   @override
   String suffixFromNow() => 'kaldı';
   @override
-  String lessThanOneMinute(int seconds) => 'biraz';
+  String lessThanOneMinute(int seconds, AgoOrFromNow _) => 'biraz';
   @override
-  String aboutAMinute(int minutes) => 'bir dakika';
+  String aboutAMinute(int minutes, AgoOrFromNow _) => 'bir dakika';
   @override
-  String minutes(int minutes) => '$minutes dakika';
+  String minutes(int minutes, AgoOrFromNow _) => '$minutes dakika';
   @override
-  String aboutAnHour(int minutes) => 'bir saat';
+  String aboutAnHour(int minutes, AgoOrFromNow _) => 'bir saat';
   @override
-  String hours(int hours) => '$hours saat';
+  String hours(int hours, AgoOrFromNow _) => '$hours saat';
   @override
-  String aDay(int hours) => 'bir gün';
+  String aDay(int hours, AgoOrFromNow _) => 'bir gün';
   @override
-  String days(int days) => '$days gün';
+  String days(int days, AgoOrFromNow _) => '$days gün';
   @override
-  String aboutAMonth(int days) => 'bir ay';
+  String aboutAMonth(int days, AgoOrFromNow _) => 'bir ay';
   @override
-  String months(int months) => '$months ay';
+  String months(int months, AgoOrFromNow _) => '$months ay';
   @override
-  String aboutAYear(int year) => 'bir yıl';
+  String aboutAYear(int year, AgoOrFromNow _) => 'bir yıl';
   @override
-  String years(int years) => '$years yıl';
+  String years(int years, AgoOrFromNow _) => '$years yıl';
   @override
   String wordSeparator() => ' ';
 }

--- a/timeago/lib/src/messages/uk_messages.dart
+++ b/timeago/lib/src/messages/uk_messages.dart
@@ -1,3 +1,4 @@
+import 'package:timeago/src/ago_or_from_now.dart';
 import 'package:timeago/src/messages/lookupmessages.dart';
 
 /// Ukrainian messages
@@ -11,27 +12,27 @@ class UkMessages implements LookupMessages {
   @override
   String suffixFromNow() => '';
   @override
-  String lessThanOneMinute(int seconds) => 'хвилину';
+  String lessThanOneMinute(int seconds, AgoOrFromNow _) => 'хвилину';
   @override
-  String aboutAMinute(int minutes) => 'хвилину';
+  String aboutAMinute(int minutes, AgoOrFromNow _) => 'хвилину';
   @override
-  String minutes(int minutes) => '$minutes ${_convert(minutes, 'minutes')}';
+  String minutes(int minutes, AgoOrFromNow _) => '$minutes ${_convert(minutes, 'minutes')}';
   @override
-  String aboutAnHour(int minutes) => 'годину';
+  String aboutAnHour(int minutes, AgoOrFromNow _) => 'годину';
   @override
-  String hours(int hours) => '$hours ${_convert(hours, 'hours')}';
+  String hours(int hours, AgoOrFromNow _) => '$hours ${_convert(hours, 'hours')}';
   @override
-  String aDay(int hours) => 'день';
+  String aDay(int hours, AgoOrFromNow _) => 'день';
   @override
-  String days(int days) => '$days ${_convert(days, 'days')}';
+  String days(int days, AgoOrFromNow _) => '$days ${_convert(days, 'days')}';
   @override
-  String aboutAMonth(int days) => 'місяць';
+  String aboutAMonth(int days, AgoOrFromNow _) => 'місяць';
   @override
-  String months(int months) => '$months ${_convert(months, 'months')}';
+  String months(int months, AgoOrFromNow _) => '$months ${_convert(months, 'months')}';
   @override
-  String aboutAYear(int year) => 'рік';
+  String aboutAYear(int year, AgoOrFromNow _) => 'рік';
   @override
-  String years(int years) => '$years ${_convert(years, 'years')}';
+  String years(int years, AgoOrFromNow _) => '$years ${_convert(years, 'years')}';
   @override
   String wordSeparator() => ' ';
 }
@@ -98,27 +99,27 @@ class UkShortMessages implements LookupMessages {
   @override
   String suffixFromNow() => '';
   @override
-  String lessThanOneMinute(int seconds) => 'тільки що';
+  String lessThanOneMinute(int seconds, AgoOrFromNow _) => 'тільки що';
   @override
-  String aboutAMinute(int minutes) => '~1 хв.';
+  String aboutAMinute(int minutes, AgoOrFromNow _) => '~1 хв.';
   @override
-  String minutes(int minutes) => '$minutes хв.';
+  String minutes(int minutes, AgoOrFromNow _) => '$minutes хв.';
   @override
-  String aboutAnHour(int minutes) => '~1 год.';
+  String aboutAnHour(int minutes, AgoOrFromNow _) => '~1 год.';
   @override
-  String hours(int hours) => '$hours год.';
+  String hours(int hours, AgoOrFromNow _) => '$hours год.';
   @override
-  String aDay(int hours) => '~1 д.';
+  String aDay(int hours, AgoOrFromNow _) => '~1 д.';
   @override
-  String days(int days) => '$days д.';
+  String days(int days, AgoOrFromNow _) => '$days д.';
   @override
-  String aboutAMonth(int days) => '~1 міс.';
+  String aboutAMonth(int days, AgoOrFromNow _) => '~1 міс.';
   @override
-  String months(int months) => '$months міс.';
+  String months(int months, AgoOrFromNow _) => '$months міс.';
   @override
-  String aboutAYear(int year) => '~1 р.';
+  String aboutAYear(int year, AgoOrFromNow _) => '~1 р.';
   @override
-  String years(int years) => '$years р.';
+  String years(int years, AgoOrFromNow _) => '$years р.';
   @override
   String wordSeparator() => ' ';
 }

--- a/timeago/lib/src/messages/ur_messages.dart
+++ b/timeago/lib/src/messages/ur_messages.dart
@@ -1,3 +1,4 @@
+import 'package:timeago/src/ago_or_from_now.dart';
 import 'package:timeago/src/messages/lookupmessages.dart';
 
 /// Urdu Messages
@@ -11,27 +12,27 @@ class UrMessages implements LookupMessages {
   @override
   String suffixFromNow() => 'اب سے';
   @override
-  String lessThanOneMinute(int seconds) => 'ایک لمحہ';
+  String lessThanOneMinute(int seconds, AgoOrFromNow _) => 'ایک لمحہ';
   @override
-  String aboutAMinute(int minutes) => 'ایک منٹ';
+  String aboutAMinute(int minutes, AgoOrFromNow _) => 'ایک منٹ';
   @override
-  String minutes(int minutes) => '${acmoConvertToUrduNumbers(minutes)} منٹ';
+  String minutes(int minutes, AgoOrFromNow _) => '${acmoConvertToUrduNumbers(minutes)} منٹ';
   @override
-  String aboutAnHour(int minutes) => 'ایک گھنٹہ';
+  String aboutAnHour(int minutes, AgoOrFromNow _) => 'ایک گھنٹہ';
   @override
-  String hours(int hours) => '${acmoConvertToUrduNumbers(hours)} گھنٹے';
+  String hours(int hours, AgoOrFromNow _) => '${acmoConvertToUrduNumbers(hours)} گھنٹے';
   @override
-  String aDay(int hours) => 'ایک دن';
+  String aDay(int hours, AgoOrFromNow _) => 'ایک دن';
   @override
-  String days(int days) => '${acmoConvertToUrduNumbers(days)} دن';
+  String days(int days, AgoOrFromNow _) => '${acmoConvertToUrduNumbers(days)} دن';
   @override
-  String aboutAMonth(int days) => 'ایک مہینہ';
+  String aboutAMonth(int days, AgoOrFromNow _) => 'ایک مہینہ';
   @override
-  String months(int months) => '${acmoConvertToUrduNumbers(months)} مہینہ';
+  String months(int months, AgoOrFromNow _) => '${acmoConvertToUrduNumbers(months)} مہینہ';
   @override
-  String aboutAYear(int year) => 'ایک سال';
+  String aboutAYear(int year, AgoOrFromNow _) => 'ایک سال';
   @override
-  String years(int years) => '${acmoConvertToUrduNumbers(years)} برس';
+  String years(int years, AgoOrFromNow _) => '${acmoConvertToUrduNumbers(years)} برس';
   @override
   String wordSeparator() => ' ';
 }
@@ -47,27 +48,27 @@ class ShortMessages implements LookupMessages {
   @override
   String suffixFromNow() => '';
   @override
-  String lessThanOneMinute(int seconds) => 'ابھی';
+  String lessThanOneMinute(int seconds, AgoOrFromNow _) => 'ابھی';
   @override
-  String aboutAMinute(int minutes) => '١ م';
+  String aboutAMinute(int minutes, AgoOrFromNow _) => '١ م';
   @override
-  String minutes(int minutes) => '${acmoConvertToUrduNumbers(minutes)} منٹ';
+  String minutes(int minutes, AgoOrFromNow _) => '${acmoConvertToUrduNumbers(minutes)} منٹ';
   @override
-  String aboutAnHour(int minutes) => '~١ گھ';
+  String aboutAnHour(int minutes, AgoOrFromNow _) => '~١ گھ';
   @override
-  String hours(int hours) => '${acmoConvertToUrduNumbers(hours)} گھ';
+  String hours(int hours, AgoOrFromNow _) => '${acmoConvertToUrduNumbers(hours)} گھ';
   @override
-  String aDay(int hours) => '~١ د';
+  String aDay(int hours, AgoOrFromNow _) => '~١ د';
   @override
-  String days(int days) => '${acmoConvertToUrduNumbers(days)} د';
+  String days(int days, AgoOrFromNow _) => '${acmoConvertToUrduNumbers(days)} د';
   @override
-  String aboutAMonth(int days) => '~١ ماہ';
+  String aboutAMonth(int days, AgoOrFromNow _) => '~١ ماہ';
   @override
-  String months(int months) => '${acmoConvertToUrduNumbers(months)} ماہ';
+  String months(int months, AgoOrFromNow _) => '${acmoConvertToUrduNumbers(months)} ماہ';
   @override
-  String aboutAYear(int year) => '~١ س';
+  String aboutAYear(int year, AgoOrFromNow _) => '~١ س';
   @override
-  String years(int years) => '${acmoConvertToUrduNumbers(years)} س';
+  String years(int years, AgoOrFromNow _) => '${acmoConvertToUrduNumbers(years)} س';
   @override
   String wordSeparator() => ' ';
 }

--- a/timeago/lib/src/messages/vi_messages.dart
+++ b/timeago/lib/src/messages/vi_messages.dart
@@ -1,3 +1,4 @@
+import 'package:timeago/src/ago_or_from_now.dart';
 import 'package:timeago/src/messages/lookupmessages.dart';
 
 /// Vietnamese messages
@@ -11,27 +12,27 @@ class ViMessages implements LookupMessages {
   @override
   String suffixFromNow() => 'nữa';
   @override
-  String lessThanOneMinute(int seconds) => 'một phút';
+  String lessThanOneMinute(int seconds, AgoOrFromNow _) => 'một phút';
   @override
-  String aboutAMinute(int minutes) => 'khoảng một phút';
+  String aboutAMinute(int minutes, AgoOrFromNow _) => 'khoảng một phút';
   @override
-  String minutes(int minutes) => '$minutes phút';
+  String minutes(int minutes, AgoOrFromNow _) => '$minutes phút';
   @override
-  String aboutAnHour(int minutes) => 'khoảng 1 tiếng';
+  String aboutAnHour(int minutes, AgoOrFromNow _) => 'khoảng 1 tiếng';
   @override
-  String hours(int hours) => '$hours tiếng';
+  String hours(int hours, AgoOrFromNow _) => '$hours tiếng';
   @override
-  String aDay(int hours) => 'một ngày';
+  String aDay(int hours, AgoOrFromNow _) => 'một ngày';
   @override
-  String days(int days) => '$days ngày';
+  String days(int days, AgoOrFromNow _) => '$days ngày';
   @override
-  String aboutAMonth(int days) => 'khoảng 1 tháng';
+  String aboutAMonth(int days, AgoOrFromNow _) => 'khoảng 1 tháng';
   @override
-  String months(int months) => '$months tháng';
+  String months(int months, AgoOrFromNow _) => '$months tháng';
   @override
-  String aboutAYear(int year) => 'khoảng 1 năm';
+  String aboutAYear(int year, AgoOrFromNow _) => 'khoảng 1 năm';
   @override
-  String years(int years) => '$years năm';
+  String years(int years, AgoOrFromNow _) => '$years năm';
   @override
   String wordSeparator() => ' ';
 }
@@ -47,27 +48,27 @@ class ViShortMessages implements LookupMessages {
   @override
   String suffixFromNow() => '';
   @override
-  String lessThanOneMinute(int seconds) => 'bây giờ';
+  String lessThanOneMinute(int seconds, AgoOrFromNow _) => 'bây giờ';
   @override
-  String aboutAMinute(int minutes) => '1 ph';
+  String aboutAMinute(int minutes, AgoOrFromNow _) => '1 ph';
   @override
-  String minutes(int minutes) => '$minutes ph';
+  String minutes(int minutes, AgoOrFromNow _) => '$minutes ph';
   @override
-  String aboutAnHour(int minutes) => '~1 h';
+  String aboutAnHour(int minutes, AgoOrFromNow _) => '~1 h';
   @override
-  String hours(int hours) => '$hours h';
+  String hours(int hours, AgoOrFromNow _) => '$hours h';
   @override
-  String aDay(int hours) => '~1 ngày';
+  String aDay(int hours, AgoOrFromNow _) => '~1 ngày';
   @override
-  String days(int days) => '$days ngày';
+  String days(int days, AgoOrFromNow _) => '$days ngày';
   @override
-  String aboutAMonth(int days) => '~1 tháng';
+  String aboutAMonth(int days, AgoOrFromNow _) => '~1 tháng';
   @override
-  String months(int months) => '$months tháng';
+  String months(int months, AgoOrFromNow _) => '$months tháng';
   @override
-  String aboutAYear(int year) => '~1 năm';
+  String aboutAYear(int year, AgoOrFromNow _) => '~1 năm';
   @override
-  String years(int years) => '$years năm';
+  String years(int years, AgoOrFromNow _) => '$years năm';
   @override
   String wordSeparator() => ' ';
 }

--- a/timeago/lib/src/messages/zh_cn_messages.dart
+++ b/timeago/lib/src/messages/zh_cn_messages.dart
@@ -1,3 +1,4 @@
+import 'package:timeago/src/ago_or_from_now.dart';
 import 'package:timeago/src/messages/lookupmessages.dart';
 
 /// Chinese-China messages
@@ -11,27 +12,27 @@ class ZhCnMessages implements LookupMessages {
   @override
   String suffixFromNow() => '后';
   @override
-  String lessThanOneMinute(int seconds) => '少于一分钟';
+  String lessThanOneMinute(int seconds, AgoOrFromNow _) => '少于一分钟';
   @override
-  String aboutAMinute(int minutes) => '约1分钟';
+  String aboutAMinute(int minutes, AgoOrFromNow _) => '约1分钟';
   @override
-  String minutes(int minutes) => '${minutes} 分';
+  String minutes(int minutes, AgoOrFromNow _) => '${minutes} 分';
   @override
-  String aboutAnHour(int minutes) => '约1小时';
+  String aboutAnHour(int minutes, AgoOrFromNow _) => '约1小时';
   @override
-  String hours(int hours) => '约 ${hours} 小时';
+  String hours(int hours, AgoOrFromNow _) => '约 ${hours} 小时';
   @override
-  String aDay(int hours) => '约1天';
+  String aDay(int hours, AgoOrFromNow _) => '约1天';
   @override
-  String days(int days) => '约 ${days} 日';
+  String days(int days, AgoOrFromNow _) => '约 ${days} 日';
   @override
-  String aboutAMonth(int days) => '约1个月';
+  String aboutAMonth(int days, AgoOrFromNow _) => '约1个月';
   @override
-  String months(int months) => '约 ${months} 月';
+  String months(int months, AgoOrFromNow _) => '约 ${months} 月';
   @override
-  String aboutAYear(int year) => '约1年';
+  String aboutAYear(int year, AgoOrFromNow _) => '约1年';
   @override
-  String years(int years) => '约 ${years} 年';
+  String years(int years, AgoOrFromNow _) => '约 ${years} 年';
   @override
   String wordSeparator() => ' ';
 }

--- a/timeago/lib/src/messages/zh_messages.dart
+++ b/timeago/lib/src/messages/zh_messages.dart
@@ -1,3 +1,4 @@
+import 'package:timeago/src/ago_or_from_now.dart';
 import 'package:timeago/src/messages/lookupmessages.dart';
 
 /// Chinese messages
@@ -11,27 +12,27 @@ class ZhMessages implements LookupMessages {
   @override
   String suffixFromNow() => '後';
   @override
-  String lessThanOneMinute(int seconds) => '少於一分鐘';
+  String lessThanOneMinute(int seconds, AgoOrFromNow _) => '少於一分鐘';
   @override
-  String aboutAMinute(int minutes) => '約1分鐘';
+  String aboutAMinute(int minutes, AgoOrFromNow _) => '約1分鐘';
   @override
-  String minutes(int minutes) => '${minutes} 分';
+  String minutes(int minutes, AgoOrFromNow _) => '${minutes} 分';
   @override
-  String aboutAnHour(int minutes) => '約1小時';
+  String aboutAnHour(int minutes, AgoOrFromNow _) => '約1小時';
   @override
-  String hours(int hours) => '約 ${hours} 小時';
+  String hours(int hours, AgoOrFromNow _) => '約 ${hours} 小時';
   @override
-  String aDay(int hours) => '約1天';
+  String aDay(int hours, AgoOrFromNow _) => '約1天';
   @override
-  String days(int days) => '約 ${days} 日';
+  String days(int days, AgoOrFromNow _) => '約 ${days} 日';
   @override
-  String aboutAMonth(int days) => '約1個月';
+  String aboutAMonth(int days, AgoOrFromNow _) => '約1個月';
   @override
-  String months(int months) => '約 ${months} 月';
+  String months(int months, AgoOrFromNow _) => '約 ${months} 月';
   @override
-  String aboutAYear(int year) => '約1年';
+  String aboutAYear(int year, AgoOrFromNow _) => '約1年';
   @override
-  String years(int years) => '約 ${years} 年';
+  String years(int years, AgoOrFromNow _) => '約 ${years} 年';
   @override
   String wordSeparator() => ' ';
 }

--- a/timeago/lib/src/timeago.dart
+++ b/timeago/lib/src/timeago.dart
@@ -1,3 +1,4 @@
+import 'package:timeago/src/ago_or_from_now.dart';
 import 'package:timeago/src/messages/en_messages.dart';
 import 'package:timeago/src/messages/es_messages.dart';
 import 'package:timeago/src/messages/lookupmessages.dart';
@@ -58,13 +59,16 @@ String format(DateTime date,
   final _clock = clock ?? DateTime.now();
   var elapsed = _clock.millisecondsSinceEpoch - date.millisecondsSinceEpoch;
 
+  AgoOrFromNow agoOrFromNow;
   String prefix, suffix;
 
   if (_allowFromNow && elapsed < 0) {
     elapsed = date.isBefore(_clock) ? elapsed : elapsed.abs();
+    agoOrFromNow = AgoOrFromNow.fromNow;
     prefix = messages.prefixFromNow();
     suffix = messages.suffixFromNow();
   } else {
+    agoOrFromNow = AgoOrFromNow.ago;
     prefix = messages.prefixAgo();
     suffix = messages.suffixAgo();
   }
@@ -78,27 +82,27 @@ String format(DateTime date,
 
   String result;
   if (seconds < 45) {
-    result = messages.lessThanOneMinute(seconds.round());
+    result = messages.lessThanOneMinute(seconds.round(), agoOrFromNow);
   } else if (seconds < 90) {
-    result = messages.aboutAMinute(minutes.round());
+    result = messages.aboutAMinute(minutes.round(), agoOrFromNow);
   } else if (minutes < 45) {
-    result = messages.minutes(minutes.round());
+    result = messages.minutes(minutes.round(), agoOrFromNow);
   } else if (minutes < 90) {
-    result = messages.aboutAnHour(minutes.round());
+    result = messages.aboutAnHour(minutes.round(), agoOrFromNow);
   } else if (hours < 24) {
-    result = messages.hours(hours.round());
+    result = messages.hours(hours.round(), agoOrFromNow);
   } else if (hours < 48) {
-    result = messages.aDay(hours.round());
+    result = messages.aDay(hours.round(), agoOrFromNow);
   } else if (days < 30) {
-    result = messages.days(days.round());
+    result = messages.days(days.round(), agoOrFromNow);
   } else if (days < 60) {
-    result = messages.aboutAMonth(days.round());
+    result = messages.aboutAMonth(days.round(), agoOrFromNow);
   } else if (days < 365) {
-    result = messages.months(months.round());
+    result = messages.months(months.round(), agoOrFromNow);
   } else if (years < 2) {
-    result = messages.aboutAYear(months.round());
+    result = messages.aboutAYear(months.round(), agoOrFromNow);
   } else {
-    result = messages.years(years.round());
+    result = messages.years(years.round(), agoOrFromNow);
   }
 
   return [prefix, result, suffix]

--- a/timeago/lib/timeago.dart
+++ b/timeago/lib/timeago.dart
@@ -1,3 +1,4 @@
+export 'package:timeago/src/ago_or_from_now.dart';
 export 'package:timeago/src/messages/ar_messages.dart';
 export 'package:timeago/src/messages/az_messages.dart';
 export 'package:timeago/src/messages/ca_messages.dart';
@@ -7,6 +8,7 @@ export 'package:timeago/src/messages/de_messages.dart';
 export 'package:timeago/src/messages/dv_messages.dart';
 export 'package:timeago/src/messages/en_messages.dart';
 export 'package:timeago/src/messages/es_messages.dart';
+export 'package:timeago/src/messages/et_messages.dart';
 export 'package:timeago/src/messages/fa_messages.dart';
 export 'package:timeago/src/messages/fr_messages.dart';
 export 'package:timeago/src/messages/gr_messages.dart';

--- a/timeago/test/all_test.dart
+++ b/timeago/test/all_test.dart
@@ -214,7 +214,7 @@ void main() {
 
 class CustomEnglishMessages extends timeago.EnMessages {
   @override
-  String lessThanOneMinute(int seconds) {
+  String lessThanOneMinute(int seconds, timeago.AgoOrFromNow _) {
     return seconds > 1 ? '$seconds seconds' : '1 second';
   }
 }

--- a/timeago_flutter/example/lib/main.dart
+++ b/timeago_flutter/example/lib/main.dart
@@ -3,6 +3,8 @@ import 'package:timeago_flutter/timeago_flutter.dart';
 
 final localesMap = <String, LookupMessages>{
   'de': DeMessages(),
+  'et': EtMessages(),
+  'et_short': EtShortMessages(),
   'fr': FrMessages(),
   'ja': JaMessages(),
   'id': IdMessages(),
@@ -39,11 +41,11 @@ class CustomEnglish extends EnMessages {
   @override
   String suffixFromNow() => '';
   @override
-  String aboutAMinute(minutes) => 'a minute';
+  String aboutAMinute(minutes, AgoOrFromNow _) => 'a minute';
   @override
-  String aboutAnHour(minutes) => 'a hour';
+  String aboutAnHour(minutes, AgoOrFromNow _) => 'an hour';
   @override
-  String aboutAMonth(days) => 'a month';
+  String aboutAMonth(days, AgoOrFromNow _) => 'a month';
 }
 
 main() async {


### PR DESCRIPTION
Added Estonian. This required a change to LookupMessages class that allows selecting different forms of the time unit (minute, hour, day etc) for past and future. This requires an additional AgoOrFromNow argument to LookupMessage methods but does not add any additional complexities for the end user. The additional argument can be simply ignored for languages where past vs future does not change the grammatical case.

This change would also make it possible to add translations for other languages with similar grammatical case systems (like Finnish and Hungarian).