### PR TITLE
Word Correction as Korean Past&Future Tense

### DIFF
--- a/packages/timeago/lib/src/messages/ko_messages.dart
+++ b/packages/timeago/lib/src/messages/ko_messages.dart
@@ -5,13 +5,13 @@ class KoMessages implements LookupMessages {
   @override
   String prefixAgo() => '';
   @override
-  String prefixFromNow() => '';
+  String prefixFromNow() => '지금부터';
   @override
   String suffixAgo() => '전';
   @override
   String suffixFromNow() => '후';
   @override
-  String lessThanOneMinute(int seconds) => '방금';
+  String lessThanOneMinute(int seconds) => '${seconds}';
   @override
   String aboutAMinute(int minutes) => '약 1분';
   @override


### PR DESCRIPTION
The word '방금' is used only in the Past tense. So i changed the word with seconds, and added prefixFromNow '지금부터'. Then it more sound natural. 

*for Korean*
'방금'이 미래 시점에 쓰이면 어색하기 때문에 과거/미래 시점에 중립적인 '{seconds}초' 의 형태로 변경하였습니다. 그리고 prefix '지금부터'를 추가해 몇 초 전인지, 몇 초 후인지 구분되게 했습니다. 