### PR TITLE
Shortening support for Turkish

### DIFF
--- a/packages/timeago/example/index.html
+++ b/packages/timeago/example/index.html
@@ -114,6 +114,7 @@
     <a href="#" class="locale-link">th_short</a>
     <a href="#" class="locale-link">tk</a>
     <a href="#" class="locale-link">tr</a>
+    <a href="#" class="locale-link">tr_short</a>
     <a href="#" class="locale-link">uk</a>
     <a href="#" class="locale-link">uk_short</a>
     <a href="#" class="locale-link">ur</a>

--- a/packages/timeago/example/main.dart
+++ b/packages/timeago/example/main.dart
@@ -77,6 +77,7 @@ main() async {
   timeago.setLocaleMessages('th_short', timeago.ThShortMessages());
   timeago.setLocaleMessages('tk', timeago.TkMessages());
   timeago.setLocaleMessages('tr', timeago.TrMessages());
+  timeago.setLocaleMessages('tr', timeago.TrShortMessages());
   timeago.setLocaleMessages('uk', timeago.UkMessages());
   timeago.setLocaleMessages('uk_short', timeago.UkShortMessages());
   timeago.setLocaleMessages('ur', timeago.UrMessages());

--- a/packages/timeago/lib/src/messages/tr_messages.dart
+++ b/packages/timeago/lib/src/messages/tr_messages.dart
@@ -35,3 +35,39 @@ class TrMessages implements LookupMessages {
   @override
   String wordSeparator() => ' ';
 }
+
+/// Turkish short Messages
+class TRShortMessages implements LookupMessages {
+  @override
+  String prefixAgo() => '';
+  @override
+  String prefixFromNow() => '';
+  @override
+  String suffixAgo() => '';
+  @override
+  String suffixFromNow() => '';
+  @override
+  String lessThanOneMinute(int seconds) => 'şimdi';
+  @override
+  String aboutAMinute(int minutes) => '1dk';
+  @override
+  String minutes(int minutes) => '${minutes}dk';
+  @override
+  String aboutAnHour(int minutes) => '~1dk';
+  @override
+  String hours(int hours) => '${hours}s';
+  @override
+  String aDay(int hours) => '~1g';
+  @override
+  String days(int days) => '${days}g';
+  @override
+  String aboutAMonth(int days) => '~1ay';
+  @override
+  String months(int months) => '${months}ay';
+  @override
+  String aboutAYear(int year) => '~1y';
+  @override
+  String years(int years) => '${years}y';
+  @override
+  String wordSeparator() => ' ';
+}

--- a/packages/timeago/lib/src/messages/tr_messages.dart
+++ b/packages/timeago/lib/src/messages/tr_messages.dart
@@ -47,15 +47,15 @@ class TRShortMessages implements LookupMessages {
   @override
   String suffixFromNow() => '';
   @override
-  String lessThanOneMinute(int seconds) => 'şimdi';
+  String lessThanOneMinute(int seconds) => 'az önce';
   @override
   String aboutAMinute(int minutes) => '1dk';
   @override
   String minutes(int minutes) => '${minutes}dk';
   @override
-  String aboutAnHour(int minutes) => '~1dk';
+  String aboutAnHour(int minutes) => '~1sa';
   @override
-  String hours(int hours) => '${hours}s';
+  String hours(int hours) => '${hours}sa';
   @override
   String aDay(int hours) => '~1g';
   @override

--- a/packages/timeago_flutter_example/lib/main.dart
+++ b/packages/timeago_flutter_example/lib/main.dart
@@ -54,6 +54,7 @@ final localesMap = <String, LookupMessages>{
   'th_short': ThShortMessages(),
   'tk': TkMessages(),
   'tr': TrMessages(),
+  'tr_short': TrShortMessages(),
   'uk': UkMessages(),
   'uk_short': UkShortMessages(),
   'ur': UrMessages(),


### PR DESCRIPTION
The abbreviation support for the Turkish language was missing, I added it.