### PR TITLE
update url from http to https

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,4 +101,4 @@ The focus of this library should be
 
 # Live Demo
 
-[Here](http://andresaraujo.github.io/timeago.dart/)
+[Here](https://andresaraujo.github.io/timeago.dart/)


### PR DESCRIPTION
Due to presence of http url, we are yet to get 5 points more, so converted http url to https.
Generally I have seen organisations prefer the score of 130.