### PR TITLE
Slightly better ergonomics for custom format override

### DIFF
--- a/packages/timeago/lib/src/timeago.dart
+++ b/packages/timeago/lib/src/timeago.dart
@@ -48,13 +48,18 @@ void setLocaleMessages(String locale, LookupMessages lookupMessages) {
 /// - If [allowFromNow] is passed, format will use the From prefix, ie. a date
 ///   5 minutes from now in 'en' locale will display as "5 minutes from now"
 String format(DateTime date,
-    {String? locale, DateTime? clock, bool allowFromNow = false}) {
+    {String? locale,
+    DateTime? clock,
+    bool allowFromNow = false,
+    LookupMessages? overrideMessages}) {
   final _locale = locale ?? _default;
   if (_lookupMessagesMap[_locale] == null) {
-    print("Locale [$_locale] has not been added, using [$_default] as fallback. To add a locale use [setLocaleMessages]");
+    print(
+        "Locale [$_locale] has not been added, using [$_default] as fallback. To add a locale use [setLocaleMessages]");
   }
   final _allowFromNow = allowFromNow;
-  final messages = _lookupMessagesMap[_locale] ?? EnMessages();
+  final messages =
+      overrideMessages ?? (_lookupMessagesMap[_locale] ?? EnMessages());
   final _clock = clock ?? DateTime.now();
   var elapsed = _clock.millisecondsSinceEpoch - date.millisecondsSinceEpoch;
 

--- a/packages/timeago/test/all_test.dart
+++ b/packages/timeago/test/all_test.dart
@@ -46,6 +46,23 @@ void main() {
       timeago.setLocaleMessages('en', timeago.EnMessages());
     });
 
+    test('should allow to override a locale in format call', () async {
+      var clock = now.add(Duration(seconds: 1));
+
+      // Override 'en' locale messages
+      timeago.setLocaleMessages('en', CustomEnglishMessages());
+
+      // Default 'en' locale
+      var result = timeago.format(now,
+          clock: clock, overrideMessages: CustomEnglishMessages());
+      expect(result, equals('1 second ago'));
+
+      clock = now.add(Duration(seconds: 5));
+      result = timeago.format(now,
+          clock: clock, overrideMessages: CustomEnglishMessages());
+      expect(result, equals('5 seconds ago'));
+    });
+
     test('should allow to add a new locale', () async {
       var clock = now.add(Duration(seconds: 170));
 

--- a/packages/timeago/test/all_test.dart
+++ b/packages/timeago/test/all_test.dart
@@ -49,9 +49,6 @@ void main() {
     test('should allow to override a locale in format call', () async {
       var clock = now.add(Duration(seconds: 1));
 
-      // Override 'en' locale messages
-      timeago.setLocaleMessages('en', CustomEnglishMessages());
-
       // Default 'en' locale
       var result = timeago.format(now,
           clock: clock, overrideMessages: CustomEnglishMessages());


### PR DESCRIPTION
### WHY?

Why I understand you can do "timeago.setLocaleMessages('en', CustomEnglishMessages());` to override custom messages for maybe that one specific usecase, the developer has to remember to reset the locale after and it's error prune.

This PR proposes a slightly better way to use custom message formats - just pass them into `.format()`

This should unlock slightly easier ways for those specific use cases that may not apply to the entire application 