### PR TITLE
Enhanced the way of using locales in format function

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,12 @@
 # timeago
 
-`timeago` is a dart library that converts a date into a humanized text. Instead of showing a date  `2020-12-12 18:30`  with `timeago` you can display something like `"now", "an hour ago", "~1y", etc`
+`timeago` is a dart library that converts a date into a humanized text. Instead of showing a date `2020-12-12 18:30` with `timeago` you can display something like `"now", "an hour ago", "~1y", etc`
 
 | timeago         | [![pub package](https://img.shields.io/pub/v/timeago.svg?label=timeago&color=blue)](https://pub.dartlang.org/packages/timeago)                         | core library    |
-|-----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------|
+| --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ | --------------- |
 | timeago_flutter | [![pub package](https://img.shields.io/pub/v/timeago_flutter.svg?label=timeago_flutter&color=blue)](https://pub.dartlang.org/packages/timeago_flutter) | flutter widgets |
 
 ---
-
 
 The easiest way to use this library via top-level function `format(date)`:
 
@@ -18,16 +17,16 @@ main() {
     final fifteenAgo = DateTime.now().subtract(Duration(minutes: 15));
 
     print(timeago.format(fifteenAgo)); // 15 minutes ago
-    print(timeago.format(fifteenAgo, locale: 'en_short')); // 15m
-    print(timeago.format(fifteenAgo, locale: 'es')); // hace 15 minutos
+    print(timeago.format(fifteenAgo, locale: DefaultLocaleShort.en)); // 15m
+    print(timeago.format(fifteenAgo, locale: DefaultLocale.es)); // hace 15 minutos
 }
 ```
 
 ##### IMPORTANT
 
-timeago library **ONLY** includes `en` and `es` messages loaded by default.
+timeago library includes most of the common locales by default.
 
-To add more of the supported languages use `timeago.setLocaleMessages(..)`. See [locale messages](packages/timeago/lib/src/messages).
+To add more of the supported languages, you can implement the class `LookupMessages` and then add it using `timeago.setLocaleMessages(..)`. See [locale messages](packages/timeago/lib/src/messages).
 
 ##### Standard for language code
 

--- a/packages/timeago/analysis_options.yaml
+++ b/packages/timeago/analysis_options.yaml
@@ -11,30 +11,30 @@ analyzer:
 
 linter:
   rules:
-     # Errors
-     - avoid_empty_else
-     - comment_references
-     - control_flow_in_finally
-     - empty_statements
-     - hash_and_equals
-     - test_types_in_equals
-     - throw_in_finally
-     - unrelated_type_equality_checks
-     - valid_regexps
+    # Errors
+    - avoid_empty_else
+    - comment_references
+    - control_flow_in_finally
+    - empty_statements
+    - hash_and_equals
+    - test_types_in_equals
+    - throw_in_finally
+    - unrelated_type_equality_checks
+    - valid_regexps
 
-     # Style
-     - avoid_init_to_null
-     - avoid_return_types_on_setters
-     - await_only_futures
-     - camel_case_types
-     - directives_ordering
-     - empty_catches
-     - empty_constructor_bodies
-     - library_names
-     - library_prefixes
-     - non_constant_identifier_names
-     - omit_local_variable_types
-     - prefer_final_fields
-     - prefer_is_not_empty
-     - slash_for_doc_comments
-     - type_init_formals
+    # Style
+    - avoid_init_to_null
+    - avoid_return_types_on_setters
+    - await_only_futures
+    - camel_case_types
+    - directives_ordering
+    - empty_catches
+    - empty_constructor_bodies
+    - library_names
+    - library_prefixes
+    - non_constant_identifier_names
+    - omit_local_variable_types
+    - prefer_final_fields
+    - prefer_is_not_empty
+    - slash_for_doc_comments
+    - type_init_formals

--- a/packages/timeago/lib/src/timeago.dart
+++ b/packages/timeago/lib/src/timeago.dart
@@ -1,14 +1,179 @@
-import 'package:timeago/src/messages/en_messages.dart';
-import 'package:timeago/src/messages/es_messages.dart';
-import 'package:timeago/src/messages/lookupmessages.dart';
+import '../timeago.dart';
 
-String _default = 'en';
+abstract class DefaultLocale {
+  static const String am = 'am';
+  static const String ar = 'ar';
+  static const String az = 'az';
+  static const String bs = 'bs';
+  static const String ca = 'ca';
+  static const String cs = 'cs';
+  static const String da = 'da';
+  static const String de = 'de';
+  static const String dv = 'dv';
+  static const String en = 'en';
+  static const String es = 'es';
+  static const String et = 'et';
+  static const String fa = 'fa';
+  static const String fi = 'fi';
+  static const String fr = 'fr';
+  static const String gr = 'gr';
+  static const String he = 'he';
+  static const String hi = 'hi';
+  static const String hu = 'hu';
+  static const String id = 'id';
+  static const String it = 'it';
+  static const String ja = 'ja';
+  static const String km = 'km';
+  static const String ko = 'ko';
+  static const String ku = 'ku';
+  static const String mn = 'mn';
+  static const String msMy = 'ms_my';
+  static const String my = 'my';
+  static const String nbNo = 'nb_no';
+  static const String nl = 'nl';
+  static const String nnNo = 'nn_no';
+  static const String pl = 'pl';
+  static const String ptBr = 'pt_br';
+  static const String ro = 'ro';
+  static const String ru = 'ru';
+  static const String rw = 'rw';
+  static const String sv = 'sv';
+  static const String ta = 'ta';
+  static const String th = 'th';
+  static const String tk = 'tk';
+  static const String tr = 'tr';
+  static const String uk = 'uk';
+  static const String ur = 'ur';
+  static const String vi = 'vi';
+  static const String zhCn = 'zh_cn';
+  static const String zh = 'zh';
+}
+
+abstract class DefaultLocaleShort {
+  static const String am = '${DefaultLocale.am}_short';
+  static const String ar = '${DefaultLocale.ar}_short';
+  static const String az = '${DefaultLocale.az}_short';
+  static const String bs = '${DefaultLocale.bs}_short';
+  static const String ca = '${DefaultLocale.ca}_short';
+  static const String cs = '${DefaultLocale.cs}_short';
+  static const String da = '${DefaultLocale.da}_short';
+  static const String de = '${DefaultLocale.de}_short';
+  static const String dv = '${DefaultLocale.dv}_short';
+  static const String en = '${DefaultLocale.en}_short';
+  static const String es = '${DefaultLocale.es}_short';
+  static const String et = '${DefaultLocale.et}_short';
+  static const String fi = '${DefaultLocale.fi}_short';
+  static const String fr = '${DefaultLocale.fr}_short';
+  static const String gr = '${DefaultLocale.gr}_short';
+  static const String he = '${DefaultLocale.he}_short';
+  static const String hi = '${DefaultLocale.hi}_short';
+  static const String hu = '${DefaultLocale.hu}_short';
+  static const String it = '${DefaultLocale.it}_short';
+  static const String km = '${DefaultLocale.km}_short';
+  static const String ku = '${DefaultLocale.ku}_short';
+  static const String mn = '${DefaultLocale.mn}_short';
+  static const String msMy = '${DefaultLocale.msMy}_short';
+  static const String my = '${DefaultLocale.my}_short';
+  static const String nbNo = '${DefaultLocale.nbNo}_short';
+  static const String nl = '${DefaultLocale.nl}_short';
+  static const String nnNo = '${DefaultLocale.nnNo}_short';
+  static const String ptBr = '${DefaultLocale.ptBr}_short';
+  static const String ro = '${DefaultLocale.ro}_short';
+  static const String ru = '${DefaultLocale.ru}_short';
+  static const String rw = '${DefaultLocale.rw}_short';
+  static const String sv = '${DefaultLocale.sv}_short';
+  static const String th = '${DefaultLocale.th}_short';
+  static const String uk = '${DefaultLocale.uk}_short';
+  static const String vi = '${DefaultLocale.vi}_short';
+}
+
+String _default = DefaultLocale.en;
 
 Map<String, LookupMessages> _lookupMessagesMap = {
-  'en': EnMessages(),
-  'en_short': EnShortMessages(),
-  'es': EsMessages(),
-  'es_short': EsShortMessages(),
+  // Default Locales
+  DefaultLocale.am: AmMessages(),
+  DefaultLocale.ar: ArMessages(),
+  DefaultLocale.az: AzMessages(),
+  DefaultLocale.bs: BsMessages(),
+  DefaultLocale.ca: CaMessages(),
+  DefaultLocale.cs: CsMessages(),
+  DefaultLocale.da: DaMessages(),
+  DefaultLocale.de: DeMessages(),
+  DefaultLocale.dv: DvMessages(),
+  DefaultLocale.en: EnMessages(),
+  DefaultLocale.es: EsMessages(),
+  DefaultLocale.et: EtMessages(),
+  DefaultLocale.fa: FaMessages(),
+  DefaultLocale.fi: FiMessages(),
+  DefaultLocale.fr: FrMessages(),
+  DefaultLocale.gr: GrMessages(),
+  DefaultLocale.he: HeMessages(),
+  DefaultLocale.hi: HiMessages(),
+  DefaultLocale.hu: HuMessages(),
+  DefaultLocale.id: IdMessages(),
+  DefaultLocale.it: ItMessages(),
+  DefaultLocale.ja: JaMessages(),
+  DefaultLocale.km: KmMessages(),
+  DefaultLocale.ko: KoMessages(),
+  DefaultLocale.ku: KuMessages(),
+  DefaultLocale.mn: MnMessages(),
+  DefaultLocale.msMy: MsMyMessages(),
+  DefaultLocale.my: MyMessages(),
+  DefaultLocale.nbNo: NbNoMessages(),
+  DefaultLocale.nl: NlMessages(),
+  DefaultLocale.nnNo: NnNoMessages(),
+  DefaultLocale.pl: PlMessages(),
+  DefaultLocale.ptBr: PtBrMessages(),
+  DefaultLocale.ro: RoMessages(),
+  DefaultLocale.ru: RuMessages(),
+  DefaultLocale.rw: RwMessages(),
+  DefaultLocale.sv: SvMessages(),
+  DefaultLocale.ta: TaMessages(),
+  DefaultLocale.th: ThMessages(),
+  DefaultLocale.tk: TkMessages(),
+  DefaultLocale.tr: TrMessages(),
+  DefaultLocale.uk: UkMessages(),
+  DefaultLocale.ur: UrMessages(),
+  DefaultLocale.vi: ViMessages(),
+  DefaultLocale.zhCn: ZhCnMessages(),
+  DefaultLocale.zh: ZhMessages(),
+
+  // Default Locales Short
+  DefaultLocaleShort.am: AmShortMessages(),
+  DefaultLocaleShort.ar: ArShortMessages(),
+  DefaultLocaleShort.az: AzShortMessages(),
+  DefaultLocaleShort.bs: BsShortMessages(),
+  DefaultLocaleShort.ca: CaShortMessages(),
+  DefaultLocaleShort.cs: CsShortMessages(),
+  DefaultLocaleShort.da: DaShortMessages(),
+  DefaultLocaleShort.de: DeShortMessages(),
+  DefaultLocaleShort.dv: DvShortMessages(),
+  DefaultLocaleShort.en: EnShortMessages(),
+  DefaultLocaleShort.es: EsShortMessages(),
+  DefaultLocaleShort.et: EtShortMessages(),
+  DefaultLocaleShort.fi: FiShortMessages(),
+  DefaultLocaleShort.fr: FrShortMessages(),
+  DefaultLocaleShort.gr: GrShortMessages(),
+  DefaultLocaleShort.he: HeShortMessages(),
+  DefaultLocaleShort.hi: HiShortMessages(),
+  DefaultLocaleShort.hu: HuShortMessages(),
+  DefaultLocaleShort.it: ItShortMessages(),
+  DefaultLocaleShort.km: KmShortMessages(),
+  DefaultLocaleShort.ku: KuShortMessages(),
+  DefaultLocaleShort.mn: MnShortMessages(),
+  DefaultLocaleShort.msMy: MsMyShortMessages(),
+  DefaultLocaleShort.my: MyShortMessages(),
+  DefaultLocaleShort.nbNo: NbNoShortMessages(),
+  DefaultLocaleShort.nl: NlShortMessages(),
+  DefaultLocaleShort.nnNo: NnNoShortMessages(),
+  DefaultLocaleShort.ptBr: PtBrShortMessages(),
+  DefaultLocaleShort.ro: RoShortMessages(),
+  DefaultLocaleShort.ru: RuShortMessages(),
+  DefaultLocaleShort.rw: RwShortMessages(),
+  DefaultLocaleShort.sv: SvShortMessages(),
+  DefaultLocaleShort.th: ThShortMessages(),
+  DefaultLocaleShort.uk: UkShortMessages(),
+  DefaultLocaleShort.vi: ViShortMessages(),
 };
 
 /// Sets the default [locale]. By default it is `en`.
@@ -51,7 +216,8 @@ String format(DateTime date,
     {String? locale, DateTime? clock, bool allowFromNow = false}) {
   final _locale = locale ?? _default;
   if (_lookupMessagesMap[_locale] == null) {
-    print("Locale [$_locale] has not been added, using [$_default] as fallback. To add a locale use [setLocaleMessages]");
+    print(
+        "Locale [$_locale] has not been added, using [$_default] as fallback. To add a locale use [setLocaleMessages]");
   }
   final _allowFromNow = allowFromNow;
   final messages = _lookupMessagesMap[_locale] ?? EnMessages();

--- a/packages/timeago/pubspec.yaml
+++ b/packages/timeago/pubspec.yaml
@@ -5,7 +5,7 @@ version: 3.4.0
 homepage: https://github.com/andresaraujo/timeago.dart
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
   intl: ^0.18.0

--- a/packages/timeago/test/all_test.dart
+++ b/packages/timeago/test/all_test.dart
@@ -25,7 +25,7 @@ void main() {
         () async {
       final clock = now.add(Duration(seconds: 1));
 
-      var result = timeago.format(now, locale: 'ko', clock: clock);
+      var result = timeago.format(now, locale: 'unknown', clock: clock);
       expect(result, equals('a moment ago'));
     });
 

--- a/packages/timeago_flutter/pubspec.lock
+++ b/packages/timeago_flutter/pubspec.lock
@@ -5,10 +5,10 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: bfe67ef28df125b7dddcea62755991f807aa39a2492a23e1550161692950bbe0
+      sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
       url: "https://pub.dev"
     source: hosted
-    version: "2.10.0"
+    version: "2.11.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -21,10 +21,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: e6a326c8af69605aec75ed6c187d06b349707a27fbff8222ca9cc2cff167975c
+      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.3.0"
   clock:
     dependency: transitive
     description:
@@ -37,10 +37,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: cfc915e6923fe5ce6e153b0723c753045de46de1b4d63771530504004a45fae0
+      sha256: "4a07be6cb69c84d677a6c3096fcf960cc3285a8330b4603e0d463d15d9bd934c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.17.1"
   fake_async:
     dependency: transitive
     description:
@@ -71,18 +71,18 @@ packages:
     dependency: transitive
     description:
       name: js
-      sha256: "5528c2f391ededb7775ec1daa69e65a2d61276f7552de2b5f7b8d34ee9fd4ab7"
+      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.5"
+    version: "0.6.7"
   matcher:
     dependency: transitive
     description:
       name: matcher
-      sha256: "16db949ceee371e9b99d22f88fa3a73c4e59fd0afed0bd25fc336eb76c198b72"
+      sha256: "6501fbd55da300384b768785b83e5ce66991266cec21af89ab9ae7f5ce1c4cbb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.13"
+    version: "0.12.15"
   material_color_utilities:
     dependency: transitive
     description:
@@ -95,18 +95,18 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "6c268b42ed578a53088d834796959e4a1814b5e9e164f147f580a386e5decf42"
+      sha256: "3c74dbf8763d36539f114c799d8a2d87343b5067e9d796ca22b5eb8437090ee3"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.0"
+    version: "1.9.1"
   path:
     dependency: transitive
     description:
       name: path
-      sha256: db9d4f58c908a4ba5953fcee2ae317c94889433e5024c27ce74a37f94267945b
+      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.2"
+    version: "1.8.3"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -156,16 +156,17 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ad540f65f92caa91bf21dfc8ffb8c589d6e4dc0c2267818b4cc2792857706206
+      sha256: eb6ac1540b26de412b3403a163d919ba86f6a973fe6cc50ae3541b80092fdcfb
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.16"
+    version: "0.5.1"
   timeago:
     dependency: "direct main"
     description:
-      path: "../timeago"
-      relative: true
-    source: path
+      name: timeago
+      sha256: a415b9a05ef64b845c859a91161fc9f689f88eaaa4c04759517d201891b99e90
+      url: "https://pub.dev"
+    source: hosted
     version: "3.4.0"
   vector_math:
     dependency: transitive
@@ -176,4 +177,4 @@ packages:
     source: hosted
     version: "2.1.4"
 sdks:
-  dart: ">=2.18.0 <3.0.0"
+  dart: ">=3.0.0-0 <4.0.0"

--- a/packages/timeago_flutter_example/pubspec.lock
+++ b/packages/timeago_flutter_example/pubspec.lock
@@ -5,10 +5,10 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: bfe67ef28df125b7dddcea62755991f807aa39a2492a23e1550161692950bbe0
+      sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
       url: "https://pub.dev"
     source: hosted
-    version: "2.10.0"
+    version: "2.11.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -21,10 +21,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: e6a326c8af69605aec75ed6c187d06b349707a27fbff8222ca9cc2cff167975c
+      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.3.0"
   clock:
     dependency: transitive
     description:
@@ -37,10 +37,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: cfc915e6923fe5ce6e153b0723c753045de46de1b4d63771530504004a45fae0
+      sha256: "4a07be6cb69c84d677a6c3096fcf960cc3285a8330b4603e0d463d15d9bd934c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.17.1"
   crypto:
     dependency: transitive
     description:
@@ -53,10 +53,10 @@ packages:
     dependency: "direct main"
     description:
       name: cupertino_icons
-      sha256: a937da4c006989739ceb4d10e3bd6cce64ca85d0fe287fc5b2b9f6ee757dcee6
+      sha256: e35129dc44c9118cee2a5603506d823bab99c68393879edb440e0090d07586be
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.3"
+    version: "1.0.5"
   fake_async:
     dependency: transitive
     description:
@@ -95,10 +95,10 @@ packages:
     dependency: transitive
     description:
       name: js
-      sha256: "5528c2f391ededb7775ec1daa69e65a2d61276f7552de2b5f7b8d34ee9fd4ab7"
+      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.5"
+    version: "0.6.7"
   lints:
     dependency: transitive
     description:
@@ -111,10 +111,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "16db949ceee371e9b99d22f88fa3a73c4e59fd0afed0bd25fc336eb76c198b72"
+      sha256: "6501fbd55da300384b768785b83e5ce66991266cec21af89ab9ae7f5ce1c4cbb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.13"
+    version: "0.12.15"
   material_color_utilities:
     dependency: transitive
     description:
@@ -127,18 +127,18 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "6c268b42ed578a53088d834796959e4a1814b5e9e164f147f580a386e5decf42"
+      sha256: "3c74dbf8763d36539f114c799d8a2d87343b5067e9d796ca22b5eb8437090ee3"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.0"
+    version: "1.9.1"
   path:
     dependency: transitive
     description:
       name: path
-      sha256: db9d4f58c908a4ba5953fcee2ae317c94889433e5024c27ce74a37f94267945b
+      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.2"
+    version: "1.8.3"
   sizer:
     dependency: "direct main"
     description:
@@ -196,16 +196,17 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ad540f65f92caa91bf21dfc8ffb8c589d6e4dc0c2267818b4cc2792857706206
+      sha256: eb6ac1540b26de412b3403a163d919ba86f6a973fe6cc50ae3541b80092fdcfb
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.16"
+    version: "0.5.1"
   timeago:
-    dependency: "direct overridden"
+    dependency: transitive
     description:
-      path: "../timeago"
-      relative: true
-    source: path
+      name: timeago
+      sha256: a415b9a05ef64b845c859a91161fc9f689f88eaaa4c04759517d201891b99e90
+      url: "https://pub.dev"
+    source: hosted
     version: "3.4.0"
   timeago_flutter:
     dependency: "direct main"
@@ -239,5 +240,5 @@ packages:
     source: hosted
     version: "2.1.4"
 sdks:
-  dart: ">=2.18.0 <3.0.0"
+  dart: ">=3.0.0-0 <4.0.0"
   flutter: ">=1.17.0"

--- a/packages/timeago_flutter_example/pubspec.yaml
+++ b/packages/timeago_flutter_example/pubspec.yaml
@@ -7,11 +7,11 @@ environment:
   sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
-  timeago_flutter: 
+  timeago_flutter:
     path: ../timeago_flutter
   flutter:
     sdk: flutter
-  cupertino_icons: ^0.1.3
+  cupertino_icons: ^1.0.0
   sizer: ^2.0.15
 
 dev_dependencies:


### PR DESCRIPTION
This PR should make using the locales easier, by pre-defining them by default statically in that the user won't make a mistake writing the wrong string locale.

So, instead of:

```dart
	final ago = format(date, locale: 'es');
	// or
	final agoShort = format(date, locale: 'es_short');
```

You can use this:

```dart
	final ago = format(date, locale: DefaultLocale.es);
	// or
	final agoShort = format(date, locale: DefaultLocaleShort.es);
```