### PR TITLE
fix RTL

### DIFF
--- a/packages/timeago/lib/src/messages/ku_messages.dart
+++ b/packages/timeago/lib/src/messages/ku_messages.dart
@@ -79,29 +79,29 @@ class KuShortMessages implements LookupMessages {
   @override
   String suffixAgo() => '';
   @override
-  String suffixFromNow() => '';
+  String suffixFromNow() => 'لە ئێستاوە';
   @override
   String lessThanOneMinute(int seconds) => 'ئێستا';
   @override
   String aboutAMinute(int minutes) => '1 خولەک';
   @override
-  String minutes(int minutes) => 'خولەک $minutes';
+  String minutes(int minutes) => '$minutes خولەک';
   @override
-  String aboutAnHour(int minutes) => 'کاژێر ~1';
+  String aboutAnHour(int minutes) => '~1 کاژێر';
   @override
-  String hours(int hours) => 'کاژێر $hours';
+  String hours(int hours) => '$hours کاژێر';
   @override
   String aDay(int hours) => '~1 ڕۆژ';
   @override
-  String days(int days) => 'رۆژ $days';
+  String days(int days) => '$days ڕۆژ';
   @override
   String aboutAMonth(int days) => '~1 مانگ';
   @override
-  String months(int months) => 'مانگ $months';
+  String months(int months) => '$months مانگ';
   @override
   String aboutAYear(int year) => '~1 ساڵ';
   @override
-  String years(int years) => 'ساڵ $years ';
+  String years(int years) => '$years ساڵ';
   @override
   String wordSeparator() => ' ';
 }


### PR DESCRIPTION
In the current version the direction of the text comes as "text number" while the correct way to write it is as "number text"

this tiny change fixes this issue with adding another translation label