### PR TITLE
feat: Add Bulgarian (bg) language support

### DIFF
--- a/packages/timeago/example/main.dart
+++ b/packages/timeago/example/main.dart
@@ -16,6 +16,8 @@ main() async {
   timeago.setLocaleMessages('ca_short', timeago.CaShortMessages());
   timeago.setLocaleMessages('cs', timeago.CsMessages());
   timeago.setLocaleMessages('cs_short', timeago.CsShortMessages());
+  timeago.setLocaleMessages('bg', timeago.BgMessages());
+  timeago.setLocaleMessages('bg_short', timeago.BgShortMessages());
   timeago.setLocaleMessages('bn', timeago.BnMessages());
   timeago.setLocaleMessages('bn_short', timeago.BnShortMessages());
   timeago.setLocaleMessages('da', timeago.DaMessages());

--- a/packages/timeago/lib/src/messages/bg_messages.dart
+++ b/packages/timeago/lib/src/messages/bg_messages.dart
@@ -1,0 +1,102 @@
+import 'package:timeago/src/messages/lookupmessages.dart';
+
+/// Bulgarian messages
+class BgMessages implements LookupMessages {
+  @override
+  String prefixAgo() => 'преди';
+  @override
+  String prefixFromNow() => 'след';
+  @override
+  String suffixAgo() => '';
+  @override
+  String suffixFromNow() => '';
+  @override
+  String lessThanOneMinute(int seconds) => 'току що';
+  @override
+  String aboutAMinute(int minutes) => 'една минута';
+  @override
+  String minutes(int minutes) => '$minutes ${_getMinutesForm(minutes)}';
+  @override
+  String aboutAnHour(int minutes) => 'един час';
+  @override
+  String hours(int hours) => '$hours ${_getHoursForm(hours)}';
+  @override
+  String aDay(int hours) => 'един ден';
+  @override
+  String days(int days) => '$days ${_getDaysForm(days)}';
+  @override
+  String aboutAMonth(int days) => 'един месец';
+  @override
+  String months(int months) => '$months ${_getMonthsForm(months)}';
+  @override
+  String aboutAYear(int year) => 'една година';
+  @override
+  String years(int years) => '$years ${_getYearsForm(years)}';
+  @override
+  String wordSeparator() => ' ';
+
+  // Helper methods for Bulgarian grammatical forms
+  String _getMinutesForm(int minutes) {
+    if (minutes == 1) return 'минута';
+    return 'минути';
+  }
+
+  String _getHoursForm(int hours) {
+    if (hours == 1) return 'час';
+    if (hours >= 2 && hours <= 4) return 'часа';
+    return 'часа';
+  }
+
+  String _getDaysForm(int days) {
+    if (days == 1) return 'ден';
+    return 'дни';
+  }
+
+  String _getMonthsForm(int months) {
+    if (months == 1) return 'месец';
+    if (months >= 2 && months <= 4) return 'месеца';
+    return 'месеца';
+  }
+
+  String _getYearsForm(int years) {
+    if (years == 1) return 'година';
+    if (years >= 2 && years <= 4) return 'години';
+    return 'години';
+  }
+}
+
+/// Bulgarian short Messages
+class BgShortMessages implements LookupMessages {
+  @override
+  String prefixAgo() => '';
+  @override
+  String prefixFromNow() => '';
+  @override
+  String suffixAgo() => '';
+  @override
+  String suffixFromNow() => '';
+  @override
+  String lessThanOneMinute(int seconds) => 'току що';
+  @override
+  String aboutAMinute(int minutes) => '1 мин';
+  @override
+  String minutes(int minutes) => '$minutes мин';
+  @override
+  String aboutAnHour(int minutes) => '~1 ч';
+  @override
+  String hours(int hours) => '$hours ч';
+  @override
+  String aDay(int hours) => '~1 д';
+  @override
+  String days(int days) => '$days д';
+  @override
+  String aboutAMonth(int days) => '~1 м';
+  @override
+  String months(int months) => '$months м';
+  @override
+  String aboutAYear(int year) => '~1 г';
+  @override
+  String years(int years) => '$years г';
+  @override
+  String wordSeparator() => ' ';
+}

--- a/packages/timeago/lib/timeago.dart
+++ b/packages/timeago/lib/timeago.dart
@@ -2,6 +2,7 @@ export 'package:timeago/src/messages/am_messages.dart';
 export 'package:timeago/src/messages/ar_messages.dart';
 export 'package:timeago/src/messages/az_messages.dart';
 export 'package:timeago/src/messages/be_messages.dart';
+export 'package:timeago/src/messages/bg_messages.dart';
 export 'package:timeago/src/messages/bn_messages.dart';
 export 'package:timeago/src/messages/bs_messages.dart';
 export 'package:timeago/src/messages/ca_messages.dart';

--- a/packages/timeago_flutter_example/lib/main.dart
+++ b/packages/timeago_flutter_example/lib/main.dart
@@ -8,6 +8,7 @@ final localesMap = <String, LookupMessages>{
   'ar_short': ArShortMessages(),
   'az': AzMessages(),
   'be': BeMessages(),
+  'bg': BgMessages(),
   'bn': BnMessages(),
   'bn_short': BnShortMessages(),
   'bs': BsMessages(),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,4 +1,4 @@
-name: timeago
+name: timeago_workspace
 
 environment:
   sdk: ">=2.12.0 <4.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,4 +1,4 @@
-name: timeago_workspace
+name: timeago
 
 environment:
   sdk: ">=2.12.0 <4.0.0"


### PR DESCRIPTION
## Description
This PR adds Bulgarian language support to the timeago package with both regular and short message formats.

## Changes
1. Added `bg_messages.dart` file with:
   - `BgMessages` class (regular Bulgarian messages)
   - `BgShortMessages` class (short Bulgarian messages)
2. Updated `timeago.dart` to export Bulgarian messages

## Bulgarian Language Details
- **Locale code**: `bg`
- **Prefix/Suffix**: Uses prefixes ("преди" for ago, "след" for from now) as is common in Bulgarian
- **Grammar**: Includes proper plural forms for Bulgarian nouns
- **Short format**: Uses common Bulgarian abbreviations (мин, ч, д, м, г)

I've tried to match the existing code patterns, but as this is my first time contributing here, I might have missed something. Feedback is welcome!